### PR TITLE
RF: Drop an unused import

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -3,7 +3,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 from simplejson import loads
-from argparse import REMAINDER
 
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc


### PR DESCRIPTION
This isn't need since we've stopped overriding run's cmd (d0f7802).