### PR TITLE
BF: Propagate run's failures

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -100,5 +100,6 @@ class ContainersRun(Interface):
                 inputs=inputs,
                 outputs=outputs,
                 message=message,
-                expand=expand):
+                expand=expand,
+                on_failure="ignore"):
             yield r


### PR DESCRIPTION
Without on_failure='ignore', containers-run will fail silently when
the run command underneath fails.

---

```
% singularity pull -n bbox.img docker://busybox:latest
% datalad add bbox.img
% datalad containers-add bbox -i bbox.img --call-fmt singularity exec {img} {cmd}
% touch dirt
```

Before change

```
% datalad containers-run --container-label bbox touch out01
<nothing>
```

After change

```
% datalad containers-run --container-label bbox touch out01
run(impossible): /home/kyle/scratch/dl-docker (dataset) [unsaved modifications present, cannot detect changes by command]
```
