### PR TITLE
Add prototype of a Docker adapter

### DIFF
--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -1,0 +1,196 @@
+"""Work with Docker images as local paths.
+
+This module provides support for saving a Docker image in a local directory and
+then loading it on-the-fly before calling `docker run ...`. The motivation for
+this is that it allows the components of an image to be tracked as objects in a
+DataLad dataset.
+
+Run `python -m datalad_container.adapters.docker --help` for details about the
+command-line interface.
+"""
+
+from glob import glob
+import hashlib
+import os
+import os.path as op
+import subprocess as sp
+import sys
+import tarfile
+import tempfile
+
+import logging
+
+lgr = logging.getLogger("datalad.containers.adapters.docker")
+
+# Note: A dockerpy dependency probably isn't worth it in the current
+# state but is worth thinking about if this module gets more
+# complicated.
+
+# FIXME: These functions assume that there is a "docker" on the path
+# that can be managed by a non-root user.  At the least, this should
+# be documented somewhere.
+
+
+def save(image, path):
+    """Save and extract a docker image to a directory.
+
+    Parameters
+    ----------
+    image : str
+        A unique identifier for a docker image.
+    path : str
+        A directory to extract the image to.
+    """
+    # Use a temporary file because docker save (or actually tar underneath)
+    # complains that stdout needs to be redirected if we use Popen and PIPE.
+    with tempfile.NamedTemporaryFile() as stream:
+        sp.check_call(["docker", "save", "-o", stream.name, image])
+        with tarfile.open(stream.name, mode="r:") as tar:
+            if not op.exists(path):
+                lgr.debug("Creating new directory at %s", path)
+                os.makedirs(path)
+            elif os.listdir(path):
+                raise OSError("Directory {} is not empty".format(path))
+            tar.extractall(path=path)
+            lgr.info("Saved %s to %s", image, path)
+
+
+def _list_images():
+    out = sp.check_output(
+        ["docker", "images", "--all", "--quiet", "--no-trunc"])
+    return out.decode().splitlines()
+
+
+def get_image(path):
+    """Return the image ID of the image extracted at `path`.
+    """
+    jsons = [j for j in glob(op.join(path, "*.json"))
+             if not j.endswith(op.sep + "manifest.json")]
+    if len(jsons) != 1:
+        raise ValueError("Could not find a unique JSON configuration object "
+                         "in {}".format(path))
+
+    with open(jsons[0], "rb") as stream:
+        return hashlib.sha256(stream.read()).hexdigest()
+
+
+def load(path):
+    """Load the Docker image from `path`.
+
+    Parameters
+    ----------
+    path : str
+        A directory with an extracted tar archive.
+
+    Returns
+    -------
+    The image ID (str)
+    """
+    # FIXME: If we load a dataset, it may overwrite the current tag. Say that
+    # (1) a dataset has a saved neurodebian:latest from a month ago, (2) a
+    # newer neurodebian:latest has been pulled, and (3) the old image have been
+    # deleted (e.g., with 'docker image prune --all'). Given all three of these
+    # things, loading the image from the dataset will tag the old neurodebian
+    # image as the latest.
+    image_id = "sha256:" + get_image(path)
+    if image_id not in _list_images():
+        lgr.debug("Loading %s", image_id)
+        cmd = ["docker", "load"]
+        p = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
+        with tarfile.open(fileobj=p.stdin, mode="w|", dereference=True) as tar:
+            tar.add(path, arcname="")
+        out, err = p.communicate()
+        return_code = p.poll()
+        if return_code:
+            lgr.warning("Running %r failed: %s", cmd, err.decode())
+            raise sp.CalledProcessError(return_code, cmd, output=out)
+    else:
+        lgr.debug("Image %s is already present", image_id)
+
+    if image_id not in _list_images():
+        raise RuntimeError(
+            "docker image {} was not successfully loaded".format(image_id))
+    return image_id
+
+
+# Command-line
+
+
+def cli_save(namespace):
+    save(namespace.image, namespace.path)
+
+
+def cli_run(namespace):
+    image_id = load(namespace.path)
+    prefix = ["docker", "run",
+              # FIXME: The -v/-w settings are convenient for testing, but they
+              # should be configurable.
+              "-v", "{}:/tmp".format(os.getcwd()),
+              "-w", "/tmp",
+              # Make it possible for the output files to be added to the
+              # dataset without the user needing to manually adjust the
+              # permissions.
+              "-u", "{}:{}".format(os.getuid(), os.getgid()),
+              "-it", "--rm",
+              image_id]
+    cmd = prefix + namespace.cmd
+    lgr.debug("Running %r", cmd)
+    sp.check_call(cmd)
+
+
+def main(args):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m datalad_container.adapters.docker",
+        description="Work with Docker images as local paths")
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true")
+
+    subparsers = parser.add_subparsers(title="subcommands")
+    # Don't continue without a subcommand.
+    subparsers.required = True
+    subparsers.dest = "command"
+
+    parser_save = subparsers.add_parser(
+        "save",
+        help="save and extract a Docker image to a directory")
+    parser_save.add_argument(
+        "image", metavar="NAME",
+        help="image to save")
+    parser_save.add_argument(
+        "path", metavar="PATH",
+        help="directory to save image in")
+    parser_save.set_defaults(func=cli_save)
+    # TODO: Add command for updating an archive directory.
+
+    parser_run = subparsers.add_parser(
+        "run",
+        help="run a command with a directory's image")
+    parser_run.add_argument(
+        "path", metavar="PATH",
+        help="run the image in this directory")
+    parser_run.add_argument(
+        "cmd", metavar="CMD", nargs=argparse.REMAINDER,
+        help="command to execute")
+    parser_run.set_defaults(func=cli_run)
+
+    namespace = parser.parse_args(args[1:])
+
+    logging.basicConfig(
+        level=logging.DEBUG if namespace.verbose else logging.INFO,
+        format="%(message)s")
+
+    namespace.func(namespace)
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv)
+    except sp.CalledProcessError as exc:
+        lgr.exception(exc)
+        sys.exit(exc.returncode)
+    except Exception as exc:
+        lgr.exception(exc)
+        sys.exit(1)


### PR DESCRIPTION
This is a RFC rather than a PR.  The code implements what I'm referring to as an "adapter" that saves/extracts a docker image to a directory in the dataset. Then it wraps the `docker run` call, loading the image from that directory if it isn't already known to docker. It should cover the core functionality that's needed to work with docker images as local paths, but there's lots of room for making this nicer/more convenient to use.

The main problem it addresses is that, unlike singularity, docker isn't a good dataset citizen.  You can run `docker save` and track the image archive in dataset, but you can't run docker directly from a local path.   You need to run `docker load` and then pass the image id/name to `docker run`.  That decouples the recorded call from the local path, so reruns use the dereferenced image rather the local path.

---

Here's a demo. First, we can save and extract the docker image archive as a local directory.

```
% datalad create /tmp/dl-docker
% cd /tmp/dl-docker
% docker pull busybox
% datalad run python -m datalad_container.adapters.docker save busybox envs/analysis
% tree envs/analysis
envs/analysis
├── 8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7.json -> ../../.git/annex/objects/33/Qj/MD5E-s1497--9f95c4d7bef1c40f5564802c6a46369a.json/MD5E-s1497--9f95c4d7bef1c40f5564802c6a46369a.json
├── f4752d3dbb207ca444ab74169ca5e21c5a47085c4aba49e367315bd4ca3a91ba
│   ├── json -> ../../../.git/annex/objects/Z6/Qm/MD5E-s1174--35f05f4b1007de5e265c051dbd91c9d1/MD5E-s1174--35f05f4b1007de5e265c051dbd91c9d1
│   ├── layer.tar -> ../../../.git/annex/objects/P2/wX/MD5E-s1360384--541cf1be59a239500f732e4d911d98a5.tar/MD5E-s1360384--541cf1be59a239500f732e4d911d98a5.tar
│   └── VERSION -> ../../../.git/annex/objects/Z8/3K/MD5E-s3--e4c2e8edac362acab7123654b9e73432/MD5E-s3--e4c2e8edac362acab7123654b9e73432
├── manifest.json -> ../../.git/annex/objects/XX/zp/MD5E-s203--6d73eb6a9647f237d0650399d683ea27.json/MD5E-s203--6d73eb6a9647f237d0650399d683ea27.json
└── repositories -> ../../.git/annex/objects/f0/wv/MD5E-s90--6a896038442d3b82854ffa23e3a20a62/MD5E-s90--6a896038442d3b82854ffa23e3a20a62

1 directory, 6 files
```

Now we register the container with `containers-add`.

```
% datalad containers-add bb -i envs/analysis --call-fmt python -m datalad_container.adapters.docker -v run {img} {cmd}
[ERROR  ] unknown arguments: ['-m', 'datalad_container.adapters.docker', '-v', 'run', '{img}', '{cmd}']
usage: datalad containers-add [-h] [-u URL] [-d DATASET]
                              [--call-fmt FORMAT [FORMAT ...]] [-i IMAGE]
                              LABEL
```

That doesn't work because the flags in format are interpreted as flags to the datalad command. And quoting the entire format wouldn't work either because it'd fail on the `containers-run` call. `datalad run` accepts two types of commands: (1) simple ones that parse to multi-item lists (`datalad run touch foo` -> `['touch', 'foo']`) and (2) compound ones that parse to a single-item list that gets unwrapped and passed with `shell=True` (`datalad run 'echo 1 >foo'` -> `['echo 1 >foo']` -> `'echo 1 >foo'`). But in order to extend the command, `containers-run` expects it to be form (1). So, we need to specify `--call-fmt` as an unquoted list.

For the moment, I'll just manually modify `cmdexec` entry in .datalad/config.

```
% datalad containers-add bb -i envs/analysis --call-fmt {img} {cmd}  # and then edit
% cat .datalad/config
[datalad "containers.bb"]
        image = envs/analysis
        cmdexec = [\"python\", \"-m\", \"datalad_container.adapters.docker\", \"run\", \"{img}\", \"{cmd}\"]
```

The key thing above is that `{img}` is the local path, not the image id.

Now we can run the image:

```
% docker rmi busybox  # just to show that the image is loaded if needed
% datalad containers-run sh -c 'ls -l /usr/ >out'
% cat out
total 4
drwxr-xr-x    2 daemon   daemon        4096 Apr  3 20:30 sbin
```

Tag it for reference:

```
% git tag busybox
```

Rerunning it doesn't make a new commit because there's no change in the underlying image.

```
% datalad rerun
% git describe --tags
busybox
```

Now let's change the underlying image, replacing it with neurodebian. There's currently no way to update an existing image directory, so we'll remove it first.

```
% datalad remove --nocheck envs/analysis
% datalad run python -m datalad_container.adapters.docker save neurodebian envs/analysis
```

Now if we rerun the previous command, the output file has changed, as expected.

```
% datalad rerun busybox
% cat out
bin
games
include
lib
local
sbin
share
src
```
