### PR TITLE
'containers-run -l name' fails

### DIFF
--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -50,15 +50,15 @@ class ContainersList(Interface):
                 # not an interesting variable
                 continue
             var_comps = var[len(var_prefix):].split('.')
-            clabel = var_comps[0]
+            cname = var_comps[0]
             ccfgname = '.'.join(var_comps[1:])
             if not ccfgname:
                 continue
 
-            cinfo = containers.get(clabel, {})
+            cinfo = containers.get(cname, {})
             cinfo[ccfgname] = value
 
-            containers[clabel] = cinfo
+            containers[cname] = cinfo
 
         for k, v in containers.items():
             if 'image' not in v:
@@ -67,7 +67,7 @@ class ContainersList(Interface):
             res = get_status_dict(
                 status='ok',
                 action='containers',
-                label=k,
+                name=k,
                 type='file',
                 path=op.join(ds.path, v.pop('image')),
                 # TODO

--- a/datalad_container/containers_remove.py
+++ b/datalad_container/containers_remove.py
@@ -39,10 +39,10 @@ class ContainersRemove(Interface):
             attempt is made to identify the dataset based on the current
             working directory""",
             constraints=EnsureDataset() | EnsureNone()),
-        label=Parameter(
-            args=("label",),
-            doc="""label of the container to remove""",
-            metavar="LABEL",
+        name=Parameter(
+            args=("name",),
+            doc="""name of the container to remove""",
+            metavar="NAME",
             constraints=EnsureStr(),
         ),
         remove_image=Parameter(
@@ -55,7 +55,7 @@ class ContainersRemove(Interface):
     @staticmethod
     @datasetmethod(name='containers_remove')
     @eval_results
-    def __call__(label, dataset=None, remove_image=False):
+    def __call__(name, dataset=None, remove_image=False):
         ds = require_dataset(dataset, check_installed=True,
                              purpose='remove a container')
 
@@ -64,7 +64,7 @@ class ContainersRemove(Interface):
             action='containers_remove',
             logger=lgr)
 
-        section = 'datalad.containers.{}'.format(label)
+        section = 'datalad.containers.{}'.format(name)
         imagecfg = '{}.image'.format(section)
 
         to_save = []
@@ -95,6 +95,6 @@ class ContainersRemove(Interface):
         if to_save:
             for r in ds.save(
                     path=to_save,
-                    message='[DATALAD] Remove container {}'.format(label)):
+                    message='[DATALAD] Remove container {}'.format(name)):
                 yield r
         yield res

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -22,10 +22,10 @@ lgr = logging.getLogger("datalad.containers.containers_run")
 
 _run_params = dict(
     Run._params_,
-    container_label=Parameter(
-        args=('-l', '--container-label',),
+    container_name=Parameter(
+        args=('-n', '--container-name',),
         metavar="NAME",
-        doc="""Specify the label of a known container to use for execution,
+        doc="""Specify the name of a known container to use for execution,
         in case multiple containers are configured."""),
 )
 
@@ -51,21 +51,21 @@ class ContainersRun(Interface):
     @staticmethod
     @datasetmethod(name='containers_run')
     @eval_results
-    def __call__(cmd, container_label=None, dataset=None,
+    def __call__(cmd, container_name=None, dataset=None,
                  inputs=None, outputs=None, message=None, expand=None):
         pwd, _ = get_command_pwds(dataset)
         ds = require_dataset(dataset, check_installed=True,
                              purpose='run a containerized command execution')
 
         # get the container list
-        containers = {c['label']: c
+        containers = {c['name']: c
                       for c in ContainersList.__call__(dataset=ds)}
 
-        if container_label is None and len(containers) == 1:
+        if container_name is None and len(containers) == 1:
             # no questions asked, take container and run
             container = containers.popitem()[1]
-        elif container_label and container_label in containers:
-            container = containers[container_label]
+        elif container_name and container_name in containers:
+            container = containers[container_name]
         else:
             # anything else is an error
             raise ValueError(

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -24,7 +24,7 @@ def test_add_noop(path):
     ok_clean_git(ds.path)
     assert_raises(TypeError, ds.containers_add)
     # fails when there is no image
-    assert_status('error', ds.containers_add('label', on_failure='ignore'))
+    assert_status('error', ds.containers_add('name', on_failure='ignore'))
     # no config change
     ok_clean_git(ds.path)
     # place a dummy "image" file
@@ -66,7 +66,7 @@ def test_container_files(ds_path, local_file, url):
     # add first "image": must end up at the configured default location
     target_path = op.join(
         ds.path, ".datalad", "test-environments", "first", "image")
-    res = ds.containers_add(label="first", url=local_file)
+    res = ds.containers_add(name="first", url=local_file)
     ok_clean_git(ds.repo)
 
     assert_result_count(res, 1, status="ok", type="file", path=target_path,
@@ -77,11 +77,11 @@ def test_container_files(ds_path, local_file, url):
     assert_result_count(res, 1)
     assert_result_count(
         res, 1,
-        label='first', type='file', action='containers', status='ok',
+        name='first', type='file', action='containers', status='ok',
         path=target_path)
 
     # and kill it again
-    # but needs label
+    # but needs name
     assert_raises(TypeError, ds.containers_remove)
     res = ds.containers_remove('first', remove_image=True)
     assert_status('ok', res)


### PR DESCRIPTION
Say I have a container named `bbox`.

```
% singularity pull -n bbox.img docker://busybox:latest
% datalad add bbox.img
% datalad containers-add bbox -i bbox.img --call-fmt singularity exec {img} {cmd}
```

If I try to run it with `-l bbox`, I get the following error.

```
% datalad containers-run -l bbox touch out
usage: datalad [-l LEVEL] [--pbs-runner {condor}] [-C PATH] [--version]
               [--dbg] [--idbg] [-c KEY=VALUE]
               [-f {default,json,json_pp,tailored,'<template>'}]
               [--report-status {success,failure,ok,notneeded,impossible,error}]
               [--report-type {dataset,file}]
               [--on-failure {ignore,continue,stop}] [--cmd]
               command [command-opts]
```

I'm guessing that's because `containers-run -l` conflicts with `datalad -l LEVEL`.  Running it with the full `--container-label` works fine.

```
% datalad containers-run --container-label bbox touch out
[INFO   ] == Command start (output follows) =====
[INFO   ] == Command exit (modification check follows) =====
get(notneeded): bbox.img (file) [already present]
add(ok): out (file)
save(ok): /home/kyle/scratch/dl-docker (dataset)
action summary:
  add (ok: 1)
  get (notneeded: 1)
  save (ok: 1)
```
