### PR TITLE
ENH: add: Support call formats that have flags

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -6,6 +6,7 @@ import re
 import logging
 import os.path as op
 from simplejson import dumps
+from argparse import REMAINDER
 
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
@@ -66,10 +67,12 @@ class ContainersAdd(Interface):
             args=("--call-fmt",),
             doc="""Command format string indicating how to execute a command in
             this container, e.g. "singularity exec {img} {cmd}". Where '{img}'
-            is a placeholder for the path to the container image and '{cmd}'
-            is replaced with the desired command.""",
+            is a placeholder for the path to the container image and '{cmd}' is
+            replaced with the desired command. [CMD: Note: This option should
+            be given at the end because all remaining arguments are consumed as
+            its value. CMD]""",
             metavar="FORMAT",
-            nargs='+',
+            nargs=REMAINDER,
             constraints=EnsureStr() | EnsureNone(),
         ),
         image=Parameter(


### PR DESCRIPTION
Without REMAINDER, --call-fmt values that have flags (e.g.,
`singularity exec -e {img} {cmd}`) fail because argparse tries to
parse the flag.

This keeps the --call-fmt flag rather than making it a positional
argument.  The advantage of using a flag is that it's more explicit
and that LABEL isn't required to come immediately before the format
arguments.  Also, datalad's parser currently fails on positional
arguments with dashes (datalad/datalad#2269), so we'd need to rename
the variable.

Re: https://github.com/datalad/datalad-container/pull/30#issuecomment-390626689