### PR TITLE
BF: Support '{pwd}' macro and use it to bind mount pwd for singularity

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -58,7 +58,11 @@ def _guess_call_fmt(ds, name, url):
     if url is None:
         return None
     elif url.startswith('shub://'):
-        return ['singularity', 'exec', '{img}', '{cmd}']
+        # use bind to always have the command pwd mounted
+        # this will typically be the dataset root
+        # if the dataset is not in the home drive, execution would
+        # fail otherwise
+        return ['singularity', 'exec', '--bind', '{pwd}', '{img}', '{cmd}']
 
 
 @build_doc

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -87,6 +87,8 @@ class ContainersRun(Interface):
                     fullcmd.extend(cmd)
                 elif c == '{img}':
                     fullcmd.append(image_path)
+                elif c == '{pwd}':
+                    fullcmd.append(pwd)
                 else:
                     fullcmd.append(c)
             cmd = fullcmd


### PR DESCRIPTION
There is a problem: If we use absolute paths for expansion the resulting run record will not be reproducible.  But if we use a relative paths, singularity will say

```
WARNING: Not mounting requested bind point (already mounted in container): .
```

and not do anything. But eventually fail in some scenarios. Example:

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/data/psyinf/scratch/multires3t/bids/sourcedata/REDACTED/dicoms'
```

(same command with abspath(pwd) works just fine).

```
singularity exec .datalad/environments/conversion/image mount
singularity exec --bind . .datalad/environments/conversion/image mount
singularity exec --bind $(pwd) .datalad/environments/conversion/image mount
```

First two yield identical results, diff to the last one is:

```diff
--- plain       2018-05-28 13:08:39.640941047 +0200
+++ abs 2018-05-28 13:09:13.744305938 +0200
@@ -11,6 +11,7 @@
 <snipp>
+zippy/scratch/data/psyinf on /home/data/psyinf/scratch/multires3t/bids type zfs (rw,nosuid,nodev,noatime,xattr,noacl)
 <snipp>
```

Leading to:

```
% singularity exec .datalad/environments/conversion/image ls $(pwd)
WARNING: Not mounting requested bind point (already mounted in container): .
ls: cannot access '/home/data/psyinf/scratch/multires3t/bids': No such file or directory
```

vs.

```
% singularity exec --bind $(pwd) .datalad/environments/conversion/image ls $(pwd)
<snip expected list of directory content>
```

Any ideas on how to solve that? @kyleam 