### PR TITLE
ENH: Store and process --call-fmt as a string

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -5,8 +5,6 @@ __docformat__ = 'restructuredtext'
 import re
 import logging
 import os.path as op
-from simplejson import dumps
-from argparse import REMAINDER
 from simplejson import loads
 
 from datalad.interface.base import Interface
@@ -58,7 +56,7 @@ def _guess_call_fmt(ds, name, url):
     if url is None:
         return None
     elif url.startswith('shub://'):
-        return ['singularity', 'exec', '{img}', '{cmd}']
+        return 'singularity exec {img} {cmd}'
 
 
 @build_doc
@@ -101,11 +99,8 @@ class ContainersAdd(Interface):
             doc="""Command format string indicating how to execute a command in
             this container, e.g. "singularity exec {img} {cmd}". Where '{img}'
             is a placeholder for the path to the container image and '{cmd}' is
-            replaced with the desired command. [CMD: Note: This option should
-            be given at the end because all remaining arguments are consumed as
-            its value. CMD]""",
+            replaced with the desired command.""",
             metavar="FORMAT",
-            nargs=REMAINDER,
             constraints=EnsureStr() | EnsureNone(),
         ),
         image=Parameter(
@@ -207,7 +202,7 @@ class ContainersAdd(Interface):
         if call_fmt:
             ds.config.set(
                 "{}.cmdexec".format(cfgbasevar),
-                dumps(call_fmt),
+                call_fmt,
                 force=True)
         # store changes
         to_save.append(op.join(".datalad", "config"))

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -24,7 +24,7 @@ def test_container_files(path):
         url=testimg_url,
         image='righthere',
         # the next one is auto-guessed
-        #call_fmt=['singularity', 'exec', '{img}', '{cmd}']
+        #call_fmt='singularity exec {img} {cmd}'
     )
     assert_result_count(
         ds.containers_list(), 1,


### PR DESCRIPTION
The current processing of the cmdexec value has a few limitations.
The replacement only occurs if cmdexec is specified as a list of
arguments.  This prevents specifying commands with redirection,
piping, and so on because those must be passed to run as a string.
Also, the replacement is restricted to items that match a placeholder
exactly, so the placeholder can't be a part of a substring.

Support these things by (1) requiring that cmdexec be a string and (2)
converting the run command to a string it can be used as an argument
to the cmdexec format call.  The conversion of the command to the
string representation is in line with datalad run, which does the same
since 9c3a65e3d (RF: run: Always use a string for the command,
2018-05-29).

Re: https://github.com/datalad/datalad-container/pull/35#discussion_r192040887
Re: https://github.com/datalad/datalad/pull/2597