### PR TITLE
ENH: default call fmt for singularity to include -e -c

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -56,7 +56,7 @@ def _guess_call_fmt(ds, name, url):
     if url is None:
         return None
     elif url.startswith('shub://'):
-        return 'singularity exec {img} {cmd}'
+        return 'singularity exec -e -c {img} {cmd}'
     elif url.startswith('dhub://'):
         return 'python -m datalad_container.adapters.docker run {img} {cmd}'
 


### PR DESCRIPTION
If we are aiming for reproducibility we should minimize if not eliminate
any influence of our working environment.  Singularity by default propages
environment, bind mounts home etc.  With `-e -c` (re)execution should become
more reproducible