### PR TITLE
BF: yield results in time

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -123,5 +123,6 @@ class ContainersRun(Interface):
                 expand=expand,
                 explicit=explicit,
                 sidecar=sidecar,
-                on_failure="ignore"):
+                on_failure="ignore",
+                return_type='generator'):
             yield r


### PR DESCRIPTION
`containers-run` used to delay results from `run`. Fixed this.