### PR TITLE
BF: Do not fail on not installed subdatasets

### DIFF
--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -44,9 +44,11 @@ class ContainersList(Interface):
                              purpose='list containers')
 
         for sub in ds.subdatasets(return_type='generator'):
-            for c in Dataset(sub['path']).containers_list():
-                c['name'] = sub['gitmodule_name'] + '/' + c['name']
-                yield c
+            subds = Dataset(sub['path'])
+            if subds.is_installed():
+                for c in subds.containers_list():
+                    c['name'] = sub['gitmodule_name'] + '/' + c['name']
+                    yield c
 
         # all info is in the dataset config!
         var_prefix = 'datalad.containers.'

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -138,3 +138,22 @@ def test_container_from_subdataset(ds_path, subds_path, local_file):
         res, 1,
         name='sub/first', type='file', action='containers', status='ok',
         path=target_path)
+
+    # not installed subdataset doesn't pose an issue:
+    sub2 = ds.create("sub2")
+    assert_result_count(ds.subdatasets(), 2, type="dataset")
+    ds.uninstall("sub2")
+    from datalad.tests.utils import assert_false
+    assert_false(sub2.is_installed())
+
+    # same results as before, not crashing or somehow confused by a not present
+    # subds:
+    res = ds.containers_list()
+    assert_result_count(res, 1)
+    # default location within the subdataset:
+    target_path = op.join(ds_path, 'sub',
+                          '.datalad', 'environments', 'first', 'image')
+    assert_result_count(
+        res, 1,
+        name='sub/first', type='file', action='containers', status='ok',
+        path=target_path)


### PR DESCRIPTION
`container-list` used to fail on subdatasets that aren't present (empty dir). This fixes it.