### PR TITLE
 ENH: run: Move the image from inputs to extra_inputs 

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -123,9 +123,6 @@ class ContainersRun(Interface):
             # just prepend and pray
             cmd = container['path'] + ' ' + cmd
 
-        # with amend inputs to also include the container image
-        inputs = (inputs or []) + [image_path]
-
         with patch.dict('os.environ',
                         {CONTAINER_NAME_ENVVAR: container['name']}):
             # fire!
@@ -133,6 +130,7 @@ class ContainersRun(Interface):
                     cmd=cmd,
                     dataset=dataset or (ds if ds.path == pwd else None),
                     inputs=inputs,
+                    extra_inputs=[image_path],
                     outputs=outputs,
                     message=message,
                     expand=expand,

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -15,6 +15,7 @@ from datalad.interface.utils import eval_results
 
 from datalad.interface.results import get_status_dict
 from datalad.interface.run import Run
+from datalad.interface.run import run_command
 from datalad.interface.run import get_command_pwds
 from datalad.interface.run import normalize_command
 from datalad_container.find_container import find_container
@@ -128,7 +129,7 @@ class ContainersRun(Interface):
         with patch.dict('os.environ',
                         {CONTAINER_NAME_ENVVAR: container['name']}):
             # fire!
-            for r in Run.__call__(
+            for r in run_command(
                     cmd=cmd,
                     dataset=dataset or (ds if ds.path == pwd else None),
                     inputs=inputs,
@@ -136,7 +137,5 @@ class ContainersRun(Interface):
                     message=message,
                     expand=expand,
                     explicit=explicit,
-                    sidecar=sidecar,
-                    on_failure="ignore",
-                    return_type='generator'):
+                    sidecar=sidecar):
                 yield r

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     packages=[pkg for pkg in find_packages('.') if pkg.startswith('datalad')],
     # datalad command suite specs from here
     install_requires=[
-        'datalad>=0.10.0',
+        'datalad>=0.11.5',
         'requests>=1.2',  # to talk to Singularity-hub
     ],
     extras_require={


### PR DESCRIPTION
`containers-run` builds on `run`, augmenting the input list with a
Singularity image.  This means that if a user then puts "{inputs}" in
their command, the image file is included too.  This is almost
certainly surprising to the user because the user has not explicitly
specified the image with --input and is probably not aware that
containers-run adds it.  Avoid this by using run_command's recently
added extra_inputs argument.

This depends on datalad/datalad#3038.

Closes #38.