### PR TITLE
 ENH: add: Support Singularity's "docker://" URI

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -9,6 +9,7 @@ import os.path as op
 from shutil import copyfile
 from simplejson import loads
 
+from datalad.cmd import Runner
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.support.param import Parameter
@@ -136,6 +137,7 @@ class ContainersAdd(Interface):
 
         ds = require_dataset(dataset, check_installed=True,
                              purpose='add container')
+        runner = Runner()
 
         # prevent madness in the config file
         if not re.match(r'^[0-9a-zA-Z-]+$', name):
@@ -216,14 +218,13 @@ class ContainersAdd(Interface):
             lgr.debug('Attempt to obtain container image from: %s', imgurl)
             if url.startswith("dhub://"):
                 from .adapters import docker
-                from subprocess import check_call
 
                 docker_image = url[len("dhub://"):]
 
                 lgr.debug(
                     "Running 'docker pull %s and saving image to %s",
                     docker_image, image)
-                check_call(["docker", "pull", docker_image])
+                runner.run(["docker", "pull", docker_image])
                 docker.save(docker_image, image)
             elif op.exists(url):
                 lgr.info("Copying local file %s to %s", url, image)

--- a/datalad_container/tests/test_schemes.py
+++ b/datalad_container/tests/test_schemes.py
@@ -1,0 +1,33 @@
+import os.path as op
+
+from datalad.api import Dataset
+from datalad.api import create
+from datalad.api import containers_add
+from datalad.api import containers_list
+from datalad.api import containers_run
+
+from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import ok_file_has_content
+from datalad.tests.utils import assert_result_count
+from datalad.tests.utils import with_tempfile
+from datalad.tests.utils import skip_if_no_network
+
+
+@skip_if_no_network
+@with_tempfile
+def test_docker(path):  # Singularity's "docker://" scheme.
+    ds = Dataset(path).create()
+    ds.containers_add(
+        "bb",
+        url=("docker://busybox@sha256:"
+             "7964ad52e396a6e045c39b5a44438424ac52e12e4d5a25d94895f2058cb863a0"))
+
+    img = op.join(ds.path, ".datalad", "environments", "bb", "image")
+    assert_result_count(ds.containers_list(), 1, path=img, name="bb")
+    ok_clean_git(path)
+
+    ds.containers_run(["sh", "-c", "cat /singularity >out"])
+    ok_file_has_content(
+        op.join(ds.path, "out"),
+        "There is no runscript defined for this container",
+        re_=True, match=False)


### PR DESCRIPTION
Ideally a user is able to use the shub:// scheme so that we resolve a
URL to register with git-annex, but, for images that are only
available from Docker, it is still useful to support Singularity's
"docker://" scheme.

Sadly, this introduces the possibility for confusion between the
"docker://" and "dhub://" prefix, but it seems worth it in order to
support pulling in Docker images via Singularity.

---

- [x] tests for adding container with "docker://" prefix