### PR TITLE
NF: add: Support updating a previous container

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -134,6 +134,15 @@ class ContainersAdd(Interface):
                 "Container names can only contain alphanumeric characters "
                 "and '-', got: '{}'".format(name))
 
+        cfgbasevar = "datalad.containers.{}".format(name)
+        if cfgbasevar + ".image" in ds.config:
+            yield get_status_dict(
+                action="containers_add", ds=ds, logger=lgr,
+                status="impossible",
+                message=("Container named %r already exists",
+                         name))
+            return
+
         if not image:
             loc_cfg_var = "datalad.containers.location"
             # TODO: We should provide an entry point (or sth similar) for extensions
@@ -209,7 +218,6 @@ class ContainersAdd(Interface):
             return
 
         # store configs
-        cfgbasevar = "datalad.containers.{}".format(name)
         if imgurl != url:
             # store originally given URL, as it resolves to something
             # different and maybe can be used to update the container

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -114,6 +114,21 @@ def test_container_files(ds_path, local_file, url):
 
 
 @with_tempfile
+@with_tree(tree={'foo.img': "foo",
+                 'bar.img': "bar"})
+@serve_path_via_http
+def test_container_update(ds_path, local_file, url):
+    url_foo = get_local_file_url(op.join(local_file, 'foo.img'))
+
+    ds = Dataset(ds_path).create()
+
+    ds.containers_add(name="foo", call_fmt="call-fmt1", url=url_foo)
+
+    res = ds.containers_add(name="foo", on_failure="ignore")
+    assert_result_count(res, 1, action="containers_add", status="impossible")
+
+
+@with_tempfile
 @with_tempfile
 @with_tree(tree={'some_container.img': "doesn't matter"})
 def test_container_from_subdataset(ds_path, subds_path, local_file):


### PR DESCRIPTION
Add `--update` switch to `containers-add` to make it possible to update aspects of an existing container.

Closes #58.
