### PR TITLE
run: Check name for slash before searching subdatasets

### DIFF
--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -7,6 +7,7 @@ import os.path as op
 
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
+from datalad.interface.common_opts import recursion_flag
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, Dataset
 from datalad.distribution.dataset import require_dataset
@@ -34,21 +35,23 @@ class ContainersList(Interface):
             attempt is made to identify the dataset based on the current
             working directory""",
             constraints=EnsureDataset() | EnsureNone()),
+        recursive=recursion_flag,
     )
 
     @staticmethod
     @datasetmethod(name='containers_list')
     @eval_results
-    def __call__(dataset=None):
+    def __call__(dataset=None, recursive=False):
         ds = require_dataset(dataset, check_installed=True,
                              purpose='list containers')
 
-        for sub in ds.subdatasets(return_type='generator'):
-            subds = Dataset(sub['path'])
-            if subds.is_installed():
-                for c in subds.containers_list():
-                    c['name'] = sub['gitmodule_name'] + '/' + c['name']
-                    yield c
+        if recursive:
+            for sub in ds.subdatasets(return_type='generator'):
+                subds = Dataset(sub['path'])
+                if subds.is_installed():
+                    for c in subds.containers_list():
+                        c['name'] = sub['gitmodule_name'] + '/' + c['name']
+                        yield c
 
         # all info is in the dataset config!
         var_prefix = 'datalad.containers.'

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -62,7 +62,9 @@ class ContainersRun(Interface):
         containers = {c['name']: c
                       for c in ContainersList.__call__(dataset=ds)}
 
-        if container_name is None and len(containers) == 1:
+        if not containers:
+            raise ValueError("No known containers. Use containers-add")
+        elif container_name is None and len(containers) == 1:
             # no questions asked, take container and run
             container = containers.popitem()[1]
         elif container_name and container_name in containers:

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -81,7 +81,7 @@ class ContainersRun(Interface):
                 raise ValueError(
                     'Container selection impossible: not specified, ambiguous '
                     'or unknown (known containers are: {})'
-                    ''.format(list(containers.keys()))
+                    .format(', '.join(containers))
                 )
 
         image_path = op.relpath(container["path"], pwd)

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -37,9 +37,11 @@ class ContainersRun(Interface):
     # the rest is put in the verbose help and manpage
     """Drop-in replacement of 'run' to perform containerized command execution
 
-    Container(s) need to be configured beforehand (see containers-add).
-    If only one container is known, it will be selected automatically;
-    otherwise a specific container has to be specified.
+    Container(s) need to be configured beforehand (see containers-add). If no
+    container is specified and only one container is configured in the current
+    dataset, it will be selected automatically. If more than one container is
+    registered in the current dataset or to access containers from subdatasets,
+    the container has to be specified.
 
     A command is generated based on the input arguments such that the
     container image itself will be recorded as an input dependency of
@@ -59,9 +61,10 @@ class ContainersRun(Interface):
                              purpose='run a containerized command execution')
 
         # get the container list
+        recurse = container_name and "/" in container_name
         containers = {c['name']: c
                       for c in ContainersList.__call__(dataset=ds,
-                                                       recursive=True)}
+                                                       recursive=recurse)}
 
         if not containers:
             raise ValueError("No known containers. Use containers-add")

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -64,10 +64,15 @@ class ContainersRun(Interface):
 
         if not containers:
             raise ValueError("No known containers. Use containers-add")
-        elif container_name is None and len(containers) == 1:
-            # no questions asked, take container and run
-            container = containers.popitem()[1]
-        elif container_name and container_name in containers:
+        elif container_name is None:
+            if len(containers) == 1:
+                # no questions asked, take container and run
+                container = containers.popitem()[1]
+            else:
+                raise ValueError("Must explicitly specify container"
+                                 " (known containers are: {})"
+                                 .format(', '.join(containers)))
+        elif container_name in containers:
             container = containers[container_name]
         else:
             from datalad.distribution.dataset import resolve_path

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -60,7 +60,8 @@ class ContainersRun(Interface):
 
         # get the container list
         containers = {c['name']: c
-                      for c in ContainersList.__call__(dataset=ds)}
+                      for c in ContainersList.__call__(dataset=ds,
+                                                       recursive=True)}
 
         if not containers:
             raise ValueError("No known containers. Use containers-add")

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -38,7 +38,7 @@ class ContainersRun(Interface):
     """Drop-in replacement of 'run' to perform containerized command execution
 
     Container(s) need to be configured beforehand (see containers-add).
-    If only one container is known, it will be selected automatically,
+    If only one container is known, it will be selected automatically;
     otherwise a specific container has to be specified.
 
     A command is generated based on the input arguments such that the

--- a/datalad_container/find_container.py
+++ b/datalad_container/find_container.py
@@ -1,0 +1,80 @@
+"""Support module for selecting a container from a dataset and its subdatasets.
+"""
+
+from datalad_container.containers_list import ContainersList
+
+# Functions tried by find_container. These are called with the current dataset,
+# the container name, and a dictionary mapping the container name to a record
+# (as returned by containers-list).
+
+
+def _get_the_one_and_only(_, name, containers):
+    if name is None:
+        if len(containers) == 1:
+            # no questions asked, take container and run
+            return list(containers.values())[0]
+        else:
+            raise ValueError("Must explicitly specify container"
+                             " (known containers are: {})"
+                             .format(', '.join(containers)))
+
+
+def _get_container_by_name(_, name, containers):
+    return containers.get(name)
+
+
+def _get_container_by_path(ds, name, containers):
+    from datalad.distribution.dataset import resolve_path
+    container_path = resolve_path(name, ds)
+    container = [c for c in containers.values()
+                 if c['path'] == container_path]
+    if len(container) == 1:
+        return container[0]
+
+
+# Entry point
+
+
+def find_container(ds, container_name):
+    """Find the container in dataset `ds` specified by `container_name`.
+
+    Parameters
+    ----------
+    ds : Dataset
+        Dataset to query.
+    container_name : str or None
+        Name in the form of how `containers-list -d ds -r` would report it
+        (e.g., "s0/s1/cname").
+
+    Returns
+    -------
+    The container record, as returned by containers-list.
+
+    Raises
+    ------
+    ValueError if a uniquely matching container cannot be found.
+    """
+    recurse = container_name and "/" in container_name
+    containers = {c['name']: c
+                  for c in ContainersList.__call__(dataset=ds,
+                                                   recursive=recurse)}
+
+    if not containers:
+        raise ValueError("No known containers. Use containers-add")
+
+    fns = [
+        _get_the_one_and_only,
+        _get_container_by_name,
+        _get_container_by_path,
+    ]
+
+    for fn in fns:
+        container = fn(ds, container_name, containers)
+        if container:
+            return container
+
+    raise ValueError(
+        'Container selection impossible: not specified, ambiguous '
+        'or unknown (known containers are: {})'
+        .format(', '.join(containers))
+    )

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -166,9 +166,14 @@ def test_container_from_subdataset(ds_path, subds_path, local_file):
     ds = Dataset(ds_path).create()
     ds.install("sub", source=subds_path)
 
+    # We come up empty without recursive:
+    res = ds.containers_list(recursive=False)
+    assert_result_count(res, 0)
+
     # query available containers from within super:
-    res = ds.containers_list()
+    res = ds.containers_list(recursive=True)
     assert_result_count(res, 1)
+
     # default location within the subdataset:
     target_path = op.join(ds_path, 'sub',
                           '.datalad', 'environments', 'first', 'image')
@@ -186,7 +191,7 @@ def test_container_from_subdataset(ds_path, subds_path, local_file):
 
     # same results as before, not crashing or somehow confused by a not present
     # subds:
-    res = ds.containers_list()
+    res = ds.containers_list(recursive=True)
     assert_result_count(res, 1)
     # default location within the subdataset:
     target_path = op.join(ds_path, 'sub',

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -53,6 +53,8 @@ def test_run_mispecified(path):
 @with_tempfile
 def test_container_files(path, super_path):
     ds = Dataset(path).create()
+    cmd = ['dir'] if on_windows else ['ls']
+
     # plug in a proper singularity image
     ds.containers_add(
         'mycontainer',
@@ -70,7 +72,7 @@ def test_container_files(path, super_path):
 
     # now we can run stuff in the container
     # and because there is just one, we don't even have to name the container
-    res = ds.containers_run(['dir'] if on_windows else ['ls'])
+    res = ds.containers_run(cmd)
     # container becomes an 'input' for `run` -> get request, but "notneeded"
     assert_result_count(
         res, 1, action='get', status='notneeded',
@@ -80,7 +82,7 @@ def test_container_files(path, super_path):
         res, 1, action='add', status='notneeded', path=ds.path, type='dataset')
 
     # same thing as we specify the container by its name:
-    res = ds.containers_run(['dir'] if on_windows else ['ls'],
+    res = ds.containers_run(cmd,
                             container_name='mycontainer')
     # container becomes an 'input' for `run` -> get request, but "notneeded"
     assert_result_count(
@@ -91,7 +93,7 @@ def test_container_files(path, super_path):
         res, 1, action='add', status='notneeded', path=ds.path, type='dataset')
 
     # we can also specify the container by its path:
-    res = ds.containers_run(['dir'] if on_windows else ['ls'],
+    res = ds.containers_run(cmd,
                             container_name=op.join(ds.path, 'righthere'))
     # container becomes an 'input' for `run` -> get request, but "notneeded"
     assert_result_count(
@@ -107,7 +109,7 @@ def test_container_files(path, super_path):
     super_ds = Dataset(super_path).create()
     super_ds.install("sub", source=path)
 
-    res = super_ds.containers_run(['dir'] if on_windows else ['ls'])
+    res = super_ds.containers_run(cmd)
     # container becomes an 'input' for `run` -> get request (needed this time)
     assert_result_count(
         res, 1, action='get', status='ok',

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -1,5 +1,7 @@
 import os.path as op
 
+from six import text_type
+
 from datalad.api import Dataset
 from datalad.api import create
 from datalad.api import containers_add
@@ -7,13 +9,25 @@ from datalad.api import containers_run
 from datalad.api import containers_list
 
 from datalad.tests.utils import ok_clean_git
+from datalad.tests.utils import assert_in
 from datalad.tests.utils import assert_result_count
+from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import skip_if_no_network
 from datalad.utils import on_windows
 
 
 testimg_url = 'shub://datalad/datalad-container:testhelper'
+
+
+@with_tempfile
+def test_run_mispecified(path):
+    ds = Dataset(path).create()
+
+    # Abort if no containers exist.
+    with assert_raises(ValueError) as cm:
+        ds.containers_run("doesn't matter")
+    assert_in("No known containers", text_type(cm.exception))
 
 
 @skip_if_no_network

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -42,6 +42,11 @@ def test_run_mispecified(path):
         ds.containers_run("doesn't matter")
     assert_in("explicitly specify container", text_type(cm.exception))
 
+    # Abort if unknown container is specified.
+    with assert_raises(ValueError) as cm:
+        ds.containers_run("doesn't matter", container_name="ghost")
+    assert_in("Container selection impossible", text_type(cm.exception))
+
 
 @skip_if_no_network
 @with_tempfile

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -109,7 +109,12 @@ def test_container_files(path, super_path):
     super_ds = Dataset(super_path).create()
     super_ds.install("sub", source=path)
 
-    res = super_ds.containers_run(cmd)
+    # When running, we don't discover containers in subdatasets
+    with assert_raises(ValueError) as cm:
+        super_ds.containers_run(cmd)
+    assert_in("No known containers", text_type(cm.exception))
+    # ... unless we need to specify the name
+    res = super_ds.containers_run(cmd, container_name="sub/mycontainer")
     # container becomes an 'input' for `run` -> get request (needed this time)
     assert_result_count(
         res, 1, action='get', status='ok',


### PR DESCRIPTION
This follows up on discussion from #64 and implements the "recurse if / is in the name" proposal.

@bpoldrack mentions there that

> If we are going to do that, we could also consider to just "parse" the name and go down that path instead of triggering a "full" recursion.

I think that's a good idea and something we should probably do at some point, but the PR punts on that and goes with the simpler "all or nothing" approach.

The main commits of interest are

  * ENH: list: Don't recurse subdatasets by default
  * ENH: run: Look for containers in subdatasets only if name has "/"

Closes #64.
