### PR TITLE
RF: do not depend on rc of datalad and scrapy which causes PIP to always consider RCs of them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     packages=[pkg for pkg in find_packages('.') if pkg.startswith('datalad')],
     # datalad command suite specs from here
     install_requires=[
-        'datalad>=0.10.0.rc5',
+        'datalad>=0.10.0',
         'requests>=1.2',  # to talk to Singularity-hub
     ],
     extras_require={


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/4969 for more info/"rationale"

Similar change was done to -crawler already