### PR TITLE
ENH: {dspath} to point to the dataset containing the container

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -105,7 +105,9 @@ class ContainersAdd(Interface):
             doc="""Command format string indicating how to execute a command in
             this container, e.g. "singularity exec {img} {cmd}". Where '{img}'
             is a placeholder for the path to the container image and '{cmd}' is
-            replaced with the desired command.""",
+            replaced with the desired command. Additional placeholders:
+            '{img_dspath}' is relative path to the dataset containing the image.
+            """,
             metavar="FORMAT",
             constraints=EnsureStr() | EnsureNone(),
         ),

--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -75,6 +75,8 @@ class ContainersList(Interface):
             if 'image' not in v:
                 # there is no container location configured
                 continue
+            if dataset and 'dspath' not in v:
+                v['dspath'] = dataset.path
             res = get_status_dict(
                 status='ok',
                 action='containers',

--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -75,14 +75,13 @@ class ContainersList(Interface):
             if 'image' not in v:
                 # there is no container location configured
                 continue
-            if dataset and 'dspath' not in v:
-                v['dspath'] = dataset.path
             res = get_status_dict(
                 status='ok',
                 action='containers',
                 name=k,
                 type='file',
                 path=op.join(ds.path, v.pop('image')),
+                parentds=ds.path,
                 # TODO
                 #state='absent' if ... else 'present'
                 **v)

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -62,6 +62,9 @@ class ContainersRun(Interface):
 
         container = find_container(ds, container_name)
         image_path = op.relpath(container["path"], pwd)
+        # container record would contain path to the (sub)dataset containing
+        # it.  If not - take current dataset, as it must be coming from it
+        container_dspath = op.relpath(container.get('dspath', ds.path), pwd)
 
         # sure we could check whether the container image is present,
         # but it might live in a subdataset that isn't even installed yet
@@ -83,8 +86,11 @@ class ContainersRun(Interface):
                     raise ValueError(
                         'cmdexe {!r} is in an old, unsupported format. '
                         'Convert it to a plain string.'.format(callspec))
-
-            cmd = callspec.format(img=image_path, cmd=cmd)
+            cmd = callspec.format(
+                img=image_path,
+                cmd=cmd,
+                dspath=op.join('{pwd}', container_dspath)
+            )
         else:
             # just prepend and pray
             cmd = container['path'] + ' ' + cmd

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -64,7 +64,7 @@ class ContainersRun(Interface):
         image_path = op.relpath(container["path"], pwd)
         # container record would contain path to the (sub)dataset containing
         # it.  If not - take current dataset, as it must be coming from it
-        image_dspath = op.relpath(container.get('dspath', ds.path), pwd)
+        image_dspath = op.relpath(container.get('parentds', ds.path), pwd)
 
         # sure we could check whether the container image is present,
         # but it might live in a subdataset that isn't even installed yet

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -64,7 +64,7 @@ class ContainersRun(Interface):
         image_path = op.relpath(container["path"], pwd)
         # container record would contain path to the (sub)dataset containing
         # it.  If not - take current dataset, as it must be coming from it
-        container_dspath = op.relpath(container.get('dspath', ds.path), pwd)
+        image_dspath = op.relpath(container.get('dspath', ds.path), pwd)
 
         # sure we could check whether the container image is present,
         # but it might live in a subdataset that isn't even installed yet
@@ -89,7 +89,7 @@ class ContainersRun(Interface):
             cmd = callspec.format(
                 img=image_path,
                 cmd=cmd,
-                dspath=op.join('{pwd}', container_dspath)
+                img_dspath=image_dspath,
             )
         else:
             # just prepend and pray

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -183,7 +183,7 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
         res, 1,
         name='sub/first', type='file', action='containers', status='ok',
         path=target_path,
-        dspath=subds.path
+        parentds=subds.path
     )
 
     # not installed subdataset doesn't pose an issue:
@@ -201,5 +201,5 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
         res, 1,
         name='sub/first', type='file', action='containers', status='ok',
         path=target_path,
-        dspath=subds.path
+        parentds=subds.path
     )

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -164,9 +164,9 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
                          )
     # add it as subdataset to a super ds:
     ds = Dataset(ds_path).create()
-    ds.install("sub", source=src_subds_path)
+    subds = ds.install("sub", source=src_subds_path)
     # add it again one level down to see actual recursion:
-    Dataset(op.join(ds.path, "sub")).install("subsub", source=src_subds_path)
+    subds.install("subsub", source=src_subds_path)
 
     # We come up empty without recursive:
     res = ds.containers_list(recursive=False)
@@ -177,12 +177,14 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
     assert_result_count(res, 2)
 
     # default location within the subdataset:
-    target_path = op.join(ds_path, 'sub',
+    target_path = op.join(subds.path,
                           '.datalad', 'environments', 'first', 'image')
     assert_result_count(
         res, 1,
         name='sub/first', type='file', action='containers', status='ok',
-        path=target_path)
+        path=target_path,
+        dspath=subds.path
+    )
 
     # not installed subdataset doesn't pose an issue:
     sub2 = ds.create("sub2")
@@ -195,10 +197,9 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
     # subds:
     res = ds.containers_list(recursive=True)
     assert_result_count(res, 2)
-    # default location within the subdataset:
-    target_path = op.join(ds_path, 'sub',
-                          '.datalad', 'environments', 'first', 'image')
     assert_result_count(
         res, 1,
         name='sub/first', type='file', action='containers', status='ok',
-        path=target_path)
+        path=target_path,
+        dspath=subds.path
+    )

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -154,19 +154,19 @@ def test_container_update(ds_path, local_file, url):
 @with_tempfile
 @with_tempfile
 @with_tree(tree={'some_container.img': "doesn't matter"})
-def test_container_from_subdataset(ds_path, subds_path, local_file):
+def test_container_from_subdataset(ds_path, src_subds_path, local_file):
 
     # prepare a to-be subdataset with a registered container
-    subds = Dataset(subds_path).create()
-    subds.containers_add(name="first",
+    src_subds = Dataset(src_subds_path).create()
+    src_subds.containers_add(name="first",
                          url=get_local_file_url(op.join(local_file,
                                                         'some_container.img'))
                          )
     # add it as subdataset to a super ds:
     ds = Dataset(ds_path).create()
-    ds.install("sub", source=subds_path)
+    ds.install("sub", source=src_subds_path)
     # add it again one level down to see actual recursion:
-    Dataset(op.join(ds.path, "sub")).install("subsub", source=subds_path)
+    Dataset(op.join(ds.path, "sub")).install("subsub", source=src_subds_path)
 
     # We come up empty without recursive:
     res = ds.containers_list(recursive=False)

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -23,8 +23,6 @@ from datalad.utils import (
 )
 from datalad.support.network import get_local_file_url
 
-import mock
-
 
 testimg_url = 'shub://datalad/datalad-container:testhelper'
 
@@ -134,22 +132,18 @@ def test_container_files(path, super_path):
 
 
 @with_tempfile
-def test_custom_call_fmt(path): # , local_file):
+@with_tree(tree={'some_container.img': "doesn't matter"})
+def test_custom_call_fmt(path, local_file):
     ds = Dataset(path).create()
     subds = ds.create('sub')
 
-    def touch_img(self, img, *args):
-        with open(img, 'w'):
-            pass
-
-    with mock.patch.object(subds.repo, 'add_url_to_file', touch_img):
-        # plug in a proper singularity image
-        subds.containers_add(
-            'mycontainer',
-            url='bogus',
-            image='righthere',
-            call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath}'
-        )
+    # plug in a proper singularity image
+    subds.containers_add(
+        'mycontainer',
+        url=get_local_file_url(op.join(local_file, 'some_container.img')),
+        image='righthere',
+        call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath}'
+    )
     ds.save()  # record the effect in super-dataset
 
     # Running should work fine either withing sub or within super

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -23,6 +23,8 @@ from datalad.utils import (
 )
 from datalad.support.network import get_local_file_url
 
+import mock
+
 
 testimg_url = 'shub://datalad/datalad-container:testhelper'
 
@@ -132,18 +134,22 @@ def test_container_files(path, super_path):
 
 
 @with_tempfile
-@with_tree(tree={'some_container.img': "doesn't matter"})
-def test_custom_call_fmt(path, local_file):
+def test_custom_call_fmt(path): # , local_file):
     ds = Dataset(path).create()
     subds = ds.create('sub')
 
-    # plug in a proper singularity image
-    subds.containers_add(
-        'mycontainer',
-        url=get_local_file_url(op.join(local_file, 'some_container.img')),
-        image='righthere',
-        call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath}'
-    )
+    def touch_img(self, img, *args):
+        with open(img, 'w'):
+            pass
+
+    with mock.patch.object(subds.repo, 'add_url_to_file', touch_img):
+        # plug in a proper singularity image
+        subds.containers_add(
+            'mycontainer',
+            url='bogus',
+            image='righthere',
+            call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath}'
+        )
     ds.save()  # record the effect in super-dataset
 
     # Running should work fine either withing sub or within super

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -1,3 +1,4 @@
+import os
 import os.path as op
 
 from six import text_type
@@ -15,7 +16,12 @@ from datalad.tests.utils import assert_raises
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import skip_if_no_network
-from datalad.utils import on_windows
+from datalad.tests.utils import swallow_outputs
+from datalad.utils import (
+    chpwd,
+    on_windows,
+)
+from datalad.support.network import get_local_file_url
 
 
 testimg_url = 'shub://datalad/datalad-container:testhelper'
@@ -123,3 +129,36 @@ def test_container_files(path, super_path):
         res, 1, action='get', status='ok',
         path=op.join(super_ds.path, 'sub', 'righthere'), type='file')
     assert_no_change(res, super_ds.path)
+
+
+@with_tempfile
+@with_tree(tree={'some_container.img': "doesn't matter"})
+def test_custom_call_fmt(path, local_file):
+    ds = Dataset(path).create()
+    subds = ds.create('sub')
+
+    # plug in a proper singularity image
+    subds.containers_add(
+        'mycontainer',
+        url=get_local_file_url(op.join(local_file, 'some_container.img')),
+        image='righthere',
+        call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath}'
+    )
+    ds.save()  # record the effect in super-dataset
+
+    # Running should work fine either withing sub or within super
+    with swallow_outputs() as cmo:
+        subds.containers_run('XXX', container_name='mycontainer')
+        assert_in('image=righthere cmd=XXX img_dspath=.', cmo.out)
+
+    with swallow_outputs() as cmo:
+        ds.containers_run('XXX', container_name='sub/mycontainer')
+        assert_in('image=sub/righthere cmd=XXX img_dspath=sub', cmo.out)
+
+    # Test within subdirectory of the super-dataset
+    subdir = op.join(ds.path, 'subdir')
+    os.mkdir(subdir)
+    with chpwd(subdir):
+        with swallow_outputs() as cmo:
+            containers_run('XXX', container_name='sub/mycontainer')
+            assert_in('image=../sub/righthere cmd=XXX img_dspath=../sub', cmo.out)


### PR DESCRIPTION
Relates to https://github.com/datalad/datalad-container/issues/75 where I
blissfully forgot about the "sandwich" of placeholders where some are
evalutated by datalad_containers (ATM only {img} and {cmd}) and the ones
to be passed into datalad-run should be double-wrapped with {}.

Since {dspath} of the dataset where actual execution to be done is of no
concern for variables at containers-run level, I have decided to expose the
(relative) path to it within {dspath}.  containers-list would return "dspath"
record with the full path to it, and then (similarly to image) it would get
converted to the relative path from current ({pwd} for datalad-run) directory.
I have not tried to "rerun" such runs, but it seems to work at least at the
"containers-run" level.

Motivation:

In my case I want to use a custom "runner" script, which is kept in the same
repository as the containers. So I would like to have a variable I could use to
refer to the top of the dataset which contains containers (which might be
different from the dataset where I actually execute, e.g. when dataset with
containers is a subdataset of the outside container).  It also relates but
orthogonal to the #72 (`containers-run` within a subdirectory), where the
[proposed patch](https://github.com/datalad/datalad-container/issues/72#issuecomment-472925070)
seems to address the issue for running within subdirectory and on my trial
plays nicely with the change proposed here -- I was able to
containers-run a container from within a subdataset within a
sub-directory of the super-dataset.

This PR ATM comes without a unit-test since first I thought to seek feedback
from datalad-containers/run gurus.