### PR TITLE
BF: run: Preserve subdirectory call context

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -95,7 +95,7 @@ class ContainersRun(Interface):
         # fire!
         for r in Run.__call__(
                 cmd=cmd,
-                dataset=ds,
+                dataset=dataset or (ds if ds.path == pwd else None),
                 inputs=inputs,
                 outputs=outputs,
                 message=message,


### PR DESCRIPTION
containers-run supplies the resolved dataset as `Run.__call__`'s dataset
argument.  Because run is called with an explicit dataset, it
interprets the paths as relative to the dataset, not the current
working directory.  This leads to confusing and incorrect behavior
when containers-run is called from a subdirectory because, from the
path handling standpoint, the containers-run call should behave as if
the caller used 'datalad run'.

Make run behave appropriately by supplying the dataset argument to run
only if (1) the dataset was explicitly given to containers-run or (2)
the current working directory matches the resolved dataset path.  The
second part isn't necessary but prevents run from repeating the
dataset resolution logic in the common case of a call from the
top-level directory of the datatset.

Note that there has been discussion of dataset resolution and path
handling in core, but the solution here works with the current
proposal in datalad/datalad#3282.

Fixes #72.

---

Haven't checked, but this may conflict with #76.  I can deal with those when that lands.