### PR TITLE
ENH: add: Log start of 'singularity build' call

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -235,6 +235,10 @@ class ContainersAdd(Interface):
                     raise ValueError("No basename in path {}".format(image))
                 if image_dir and not op.exists(image_dir):
                     os.makedirs(image_dir)
+
+                lgr.info("Building Singularity image for %s "
+                         "(this may take some time)",
+                         url)
                 runner.run(["singularity", "build", image_basename, url],
                            cwd=image_dir or None)
             elif op.exists(url):


### PR DESCRIPTION
Building a singularity image can take a while, so we should at least
give some indication of progress.  Ideally we would provide feedback
over the course of the process.  However, processing singularity's
output by giving a callable to log_{stdout,stderr} is tricky
because (1) the output as well as target stream differ substantially
between singularity version 2 and version 3 and (2) 'singularity
build' doesn't seem to adjust its output when it's not connected to a
tty, so it tries to do things like update the progress bars in place.

An alternative would be to dump the output to the terminal with
run(..., log_online=True, log_stdout=False, log_stderr), but datalad
generally avoids straight dumps of output from other programs, so
let's stick with an initial log for now.

Re: #69