### PR TITLE
CHANGELOG.md: Prepare entries for 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The minimum required DataLad version is now 0.11.5.
   `extra_inputs` argument so that a run command's "{inputs}" field is
   restricted to inputs that the caller explicitly specified.
 
+- During execution, `containers-run` now sets the environment variable
+  `DATALAD_CONTAINER_NAME` to the name of the container.
+
 ### Fixes
 
 - `containers-run` mishandled paths when called from a subdirectory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The minimum required DataLad version is now 0.11.5.
 - `containers-run` didn't provide an informative error message when
   `cmdexec` contained an unknown placeholder.
 
+- `containers-add` ignores the `--update` flag when the container
+  doesn't yet exist, but it confusingly still used the word "update"
+  in the commit message.
 
 ## 0.3.1 (Mar 05, 2019) -- Upgrayeddd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ This is a high level and scarce summary of the changes between releases.  We
 would recommend to consult log of the [DataLad git
 repository](http://github.com/datalad/datalad-container) for more details.
 
+## 0.4.0 () --
+
+The minimum required DataLad version is now 0.11.5.
+
+### New features
+
+- The call format gained the "{img_dspath}" placeholder, which expands
+  to the relative path of the dataset that contains the image.  This
+  is useful for pointing to a wrapper script that is bundled in the
+  same subdataset as a container.
+
+- `containers-run` now passes the container image to `run` via its
+  `extra_inputs` argument so that a run command's "{inputs}" field is
+  restricted to inputs that the caller explicitly specified.
+
+### Fixes
+
+- `containers-run` mishandled paths when called from a subdirectory.
+
+- `containers-run` didn't provide an informative error message when
+  `cmdexec` contained an unknown placeholder.
+
+
 ## 0.3.1 (Mar 05, 2019) -- Upgrayeddd
 
 ### Fixes


### PR DESCRIPTION
This is waiting for a DataLad 0.11.5 release for gh-60:

<details>
<summary>Changes for 0.4.0</summary>

```
# Generated with
#   git log --format="?  %s%n   %h^-1" --reverse --first-parent 0.3.1..origin/master
#
#
# ?  = unprocessed and undecided
# -  = decided not to include
# +  = included
# +* = included, but might still be bits that should be added

-  Merge pull request #73 from kyleam/tst-run-rev-save
   0cd88cf^-1
-  Merge pull request #74 from yarikoptic/bf-datalad-version
   d49bf7d^-1
+  BF: run: Preserve subdirectory call context (#77)
   f4fa5fc^-1
+  Merge pull request #76 from yarikoptic/enh-dspath
   36675b0^-1
-  Merge pull request #78 from kyleam/log-sing-build
   a055e46^-1
+  Merge pull request #80 from kyleam/cmdexec-unknown
   9c5712d^-1

```

In addition, there's an entry for the unmerged gh-60.

</details>
