### PR TITLE
ENH: set DATALAD_CONTAINER_NAME env var while running a container

### DIFF
--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -155,14 +155,16 @@ def test_custom_call_fmt(path, local_file):
         'mycontainer',
         url=get_local_file_url(op.join(local_file, 'some_container.img')),
         image='righthere',
-        call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath}'
+        call_fmt='echo image={img} cmd={cmd} img_dspath={img_dspath} '
+                 # and environment variable being set/propagated by default
+                 'name=$DATALAD_CONTAINER_NAME'
     )
     ds.save()  # record the effect in super-dataset
 
     # Running should work fine either withing sub or within super
     with swallow_outputs() as cmo:
         subds.containers_run('XXX', container_name='mycontainer')
-        assert_in('image=righthere cmd=XXX img_dspath=.', cmo.out)
+        assert_in('image=righthere cmd=XXX img_dspath=. name=mycontainer', cmo.out)
 
     with swallow_outputs() as cmo:
         ds.containers_run('XXX', container_name='sub/mycontainer')


### PR DESCRIPTION
The main reason was due to the fact that older (prior 3.0?) singularity
followed the symlinked for the annexed file to set
SINGULARITY_NAME and SINGULARITY_CONTAINER env vars:

    $> singularity --version ; singularity exec images/repronim/repronim-reproin--0.5.4.sing bash -c 'export | grep SING'
    2.6.1-dist
    declare -x SINGULARITY_CONTAINER="MD5E-s301797407--a50bf88c0fb53809154e42e8d08a482e.4.sing"
    declare -x SINGULARITY_NAME="MD5E-s301797407--a50bf88c0fb53809154e42e8d08a482e.4.sing"

That seems was fixed in 3.x;

	$> singularity --version ; singularity exec images/repronim/repronim-reproin--0.5.4.sing bash -c 'export | grep SING'
	singularity version 3.0.3+ds
	declare -x SINGULARITY_APPNAME=""
	declare -x SINGULARITY_CONTAINER="/home/yoh/proj/repronim/containers/images/repronim/repronim-reproin--0.5.4.sing"
	declare -x SINGULARITY_NAME="repronim-reproin--0.5.4.sing"

but

- in many places 2.x is still be used
- our container name but default does not even match container
  name and just called "image"
- even when it is set to some reasonable named file, name of the
  container could still be different

So I thought that it should only be advantageous to expose our container name
to underlying process, possibly a shim, to take advantage of it, e.g. to set
PS1 env variable for interactive shell etc.