### PR TITLE
BF: report "Update " in commit message only if an existing image was actually updated

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -208,8 +208,10 @@ class ContainersAdd(Interface):
         # collect bits for a final and single save() call
         to_save = []
         imgurl = url
+        was_updated = False
         if url:
             if update and op.lexists(image):
+                was_updated = True
                 # XXX: check=False is used to avoid dropping the image. It
                 # should use drop=False if remove() gets such an option (see
                 # DataLad's gh-2673).
@@ -287,7 +289,7 @@ class ContainersAdd(Interface):
         for r in ds.save(
                 path=to_save,
                 message="[DATALAD] {do} containerized environment '{name}'".format(
-                    do="Update" if update else "Configure",
+                    do="Update" if was_updated else "Configure",
                     name=name)):
             yield r
         result["status"] = "ok"

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -150,6 +150,15 @@ def test_container_update(ds_path, local_file, url):
     assert_result_count(res, 1, action="save", status="ok")
     ok_file_has_content(op.join(ds.path, img), "bar")
 
+    # Test commit message
+    # In the above case it was updating existing image so should have "Update "
+    get_commit_msg = lambda *args: ds.repo.format_commit('%B')
+    assert_in("Update ", get_commit_msg())
+
+    # If we add a new image with update=True should say Configure
+    res = ds.containers_add(name="foo2", update=True, url=url_bar)
+    assert_in("Configure ", get_commit_msg())
+
 
 @with_tempfile
 @with_tempfile


### PR DESCRIPTION
I tend to use --update while adding or updating existing image.  That leads to
IMHO erroneous commit message that an image was updated whenever it was freshly
added/configured.  Docstring for --update says "If a container with `name` does
not already exist, this option is ignored.", so reporting Conffigure in the
cases when it was "ignored" is IMHO a correct thing to do