### PR TITLE
BF: even more bogus URL + remove image before replacing with a new one

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -246,6 +246,9 @@ class ContainersAdd(Interface):
                 image_dir = op.dirname(image)
                 if image_dir and not op.exists(image_dir):
                     os.makedirs(image_dir)
+                if op.lexists(image):
+                    lgr.debug("Image file %s already exists, removing", image)
+                    os.unlink(image)
                 copyfile(url, image)
             else:
                 try:

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -38,8 +38,11 @@ def test_add_noop(path):
     ok_clean_git(ds.path)
     # config will be added, as long as there is a file, even when URL access
     # fails
-    res = ds.containers_add('broken', url='bogus', image='dummy',
-                            on_failure='ignore')
+    res = ds.containers_add(
+        'broken',
+        url='bogus-protocol://bogus-server', image='dummy',
+        on_failure='ignore'
+    )
     assert_status('ok', res)
     assert_result_count(res, 1, action='save', status='ok')
 


### PR DESCRIPTION
Partially addresses (the _noop test) #85 

The 2nd one is questionable, so up for discussion -- could be dropped.
more bogus url is not ultimate protection, but I didn't want to `chpwd`