### PR TITLE
ENH: list: Use custom result renderer by default

### DIFF
--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -50,7 +50,12 @@ class ContainersList(Interface):
             for sub in ds.subdatasets(return_type='generator'):
                 subds = Dataset(sub['path'])
                 if subds.is_installed():
-                    for c in subds.containers_list(recursive=recursive):
+                    for c in subds.containers_list(recursive=recursive,
+                                                   return_type='generator',
+                                                   on_failure='ignore',
+                                                   result_filter=None,
+                                                   result_renderer=None,
+                                                   result_xfm=None):
                         c['name'] = sub['gitmodule_name'] + '/' + c['name']
                         c['refds'] = refds
                         yield c

--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -44,6 +44,7 @@ class ContainersList(Interface):
     def __call__(dataset=None, recursive=False):
         ds = require_dataset(dataset, check_installed=True,
                              purpose='list containers')
+        refds = ds.path
 
         if recursive:
             for sub in ds.subdatasets(return_type='generator'):
@@ -51,6 +52,7 @@ class ContainersList(Interface):
                 if subds.is_installed():
                     for c in subds.containers_list(recursive=recursive):
                         c['name'] = sub['gitmodule_name'] + '/' + c['name']
+                        c['refds'] = refds
                         yield c
 
         # all info is in the dataset config!
@@ -81,6 +83,7 @@ class ContainersList(Interface):
                 name=k,
                 type='file',
                 path=op.join(ds.path, v.pop('image')),
+                refds=refds,
                 parentds=ds.path,
                 # TODO
                 #state='absent' if ... else 'present'

--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -11,10 +11,13 @@ from datalad.interface.common_opts import recursion_flag
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod, EnsureDataset, Dataset
 from datalad.distribution.dataset import require_dataset
+from datalad.interface.utils import default_result_renderer
 from datalad.interface.utils import eval_results
 from datalad.support.constraints import EnsureNone
+import datalad.support.ansi_colors as ac
 from datalad.interface.results import get_status_dict
 from datalad.coreapi import subdatasets
+from datalad.ui import ui
 
 lgr = logging.getLogger("datalad.containers.containers_list")
 
@@ -27,6 +30,7 @@ class ContainersList(Interface):
     """List containers known to a dataset
     """
 
+    result_renderer = 'tailored'
     # parameters of the command, must be exhaustive
     _params_ = dict(
         dataset=Parameter(
@@ -94,3 +98,13 @@ class ContainersList(Interface):
                 #state='absent' if ... else 'present'
                 **v)
             yield res
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        if res["action"] != "containers":
+            default_result_renderer(res)
+        else:
+            ui.message(
+                "{name} -> {path}"
+                .format(name=ac.color_word(res["name"], ac.MAGENTA),
+                        path=op.relpath(res["path"], res["refds"])))

--- a/datalad_container/find_container.py
+++ b/datalad_container/find_container.py
@@ -57,7 +57,12 @@ def find_container(ds, container_name):
     recurse = container_name and "/" in container_name
     containers = {c['name']: c
                   for c in ContainersList.__call__(dataset=ds,
-                                                   recursive=recurse)}
+                                                   recursive=recurse,
+                                                   return_type='generator',
+                                                   on_failure='ignore',
+                                                   result_filter=None,
+                                                   result_renderer=None,
+                                                   result_xfm=None)}
 
     if not containers:
         raise ValueError("No known containers. Use containers-add")

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -69,6 +69,12 @@ def test_add_local_path(path, local_file):
     assert_in(ds.repo.WEB_UUID, ds.repo.whereis(bar_target))
 
 
+RAW_KWDS = dict(return_type='list',
+                result_filter=None,
+                result_renderer=None,
+                result_xfm=None)
+
+
 @with_tempfile
 @with_tree(tree={'some_container.img': "doesn't matter"})
 @serve_path_via_http
@@ -89,7 +95,7 @@ def test_container_files(ds_path, local_file, url):
     ds.save(message="Configure container mountpoint")
 
     # no containers yet:
-    res = ds.containers_list()
+    res = ds.containers_list(**RAW_KWDS)
     assert_result_count(res, 0)
 
     # add first "image": must end up at the configured default location
@@ -102,7 +108,7 @@ def test_container_files(ds_path, local_file, url):
                         action="containers_add")
     ok_(op.lexists(target_path))
 
-    res = ds.containers_list()
+    res = ds.containers_list(**RAW_KWDS)
     assert_result_count(res, 1)
     assert_result_count(
         res, 1,
@@ -114,7 +120,7 @@ def test_container_files(ds_path, local_file, url):
     assert_raises(TypeError, ds.containers_remove)
     res = ds.containers_remove('first', remove_image=True)
     assert_status('ok', res)
-    assert_result_count(ds.containers_list(), 0)
+    assert_result_count(ds.containers_list(**RAW_KWDS), 0)
     # image removed
     assert(not op.lexists(target_path))
 
@@ -182,11 +188,11 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
     subds.install("subsub", source=src_subds_path)
 
     # We come up empty without recursive:
-    res = ds.containers_list(recursive=False)
+    res = ds.containers_list(recursive=False, **RAW_KWDS)
     assert_result_count(res, 0)
 
     # query available containers from within super:
-    res = ds.containers_list(recursive=True)
+    res = ds.containers_list(recursive=True, **RAW_KWDS)
     assert_result_count(res, 2)
     assert_in_results(res, action="containers", refds=ds.path)
 
@@ -209,7 +215,7 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
 
     # same results as before, not crashing or somehow confused by a not present
     # subds:
-    res = ds.containers_list(recursive=True)
+    res = ds.containers_list(recursive=True, **RAW_KWDS)
     assert_result_count(res, 2)
     assert_result_count(
         res, 1,

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -16,6 +16,7 @@ from datalad.tests.utils import assert_status
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_result_count
 from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_in_results
 from datalad.tests.utils import assert_not_in
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import serve_path_via_http
@@ -187,6 +188,7 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
     # query available containers from within super:
     res = ds.containers_list(recursive=True)
     assert_result_count(res, 2)
+    assert_in_results(res, action="containers", refds=ds.path)
 
     # default location within the subdataset:
     target_path = op.join(subds.path,


### PR DESCRIPTION
```
The default containers-list output is missing information that is
likely of interest to the caller:

  $ datalad containers-list -r
  containers(ok): subds/subsub/.datalad/environments/lolcow/image (file)
  containers(ok): subds/.datalad/environments/insub/image (file)
  containers(ok): .datalad/environments/bbd/image (file)
  containers(ok): .datalad/environments/bb/image (file)
  action summary:
    containers (ok: 4)

Most importantly, it doesn't include the name of the container.  Use a
custom renderer to transform the above output into

  $ datalad containers-list -r
  subds/subsub/lolcow (shub://GodloveD/lolcow): subds/subsub/.datalad/environments/lolcow/image
  subds/insub (shub://GodloveD/busybox): subds/.datalad/environments/insub/image
  bb (shub://GodloveD/busybox): .datalad/environments/bb/image
  bbd: .datalad/environments/bbd/image
```

Closes #52.

---

While I think we need a tailored renderer for `containers-list`, I don't have any strong feelings on how it should look, aside from including the container name.  Please let me know if you have other ideas.
