### PR TITLE
Take full path to sys.executable

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -56,7 +56,7 @@ def _guess_call_fmt(ds, name, url):
     elif url.startswith('shub://') or url.startswith('docker://'):
         return 'singularity exec {img} {cmd}'
     elif url.startswith('dhub://'):
-        return op.basename(sys.executable) + ' -m datalad_container.adapters.docker run {img} {cmd}'
+        return sys.executable + ' -m datalad_container.adapters.docker run {img} {cmd}'
 
 
 @build_doc


### PR DESCRIPTION
I rushed to take only the basename - might not work in virtual env where it would be just python but of different version