### PR TITLE
Docker adapter tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # travis-ci.org definition for DataLad build
 language: python
 
+services:
+  - docker
+
 git:
   # we use submodules to be managed with datalad
   submodules: false

--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -188,9 +188,10 @@ def main(args):
 if __name__ == "__main__":
     try:
         main(sys.argv)
-    except sp.CalledProcessError as exc:
-        lgr.exception(exc)
-        sys.exit(exc.returncode)
     except Exception as exc:
-        lgr.exception(exc)
-        sys.exit(1)
+        lgr.exception("Failed to execute %s", sys.argv)
+        if isinstance(exc, sp.CalledProcessError):
+            excode = exc.returncode
+        else:
+            excode = 1
+        sys.exit(excode)

--- a/datalad_container/adapters/tests/test_docker.py
+++ b/datalad_container/adapters/tests/test_docker.py
@@ -1,0 +1,97 @@
+from distutils.spawn import find_executable
+import os.path as op
+import sys
+
+import datalad_container.adapters.docker as da
+from datalad.cmd import Runner
+from datalad.utils import swallow_outputs
+from datalad.support.exceptions import CommandError
+from datalad.tests.utils import (
+    SkipTest,
+    assert_in,
+    assert_raises,
+    eq_,
+    ok_exists,
+    with_tempfile,
+    with_tree,
+)
+
+if not find_executable("docker"):
+    raise SkipTest("'docker' not found on path")
+
+RUNNER = Runner()
+
+
+def call(args, **kwds):
+    return RUNNER.run(
+        [sys.executable, "-m", "datalad_container.adapters.docker"] + args,
+        **kwds)
+
+
+def list_images(args):
+    cmd = ["docker", "images", "--quiet", "--no-trunc"] + args
+    return RUNNER.run(cmd)[0].strip().split()
+
+
+def images_exist(args):
+    return bool(list_images(args))
+
+
+@with_tempfile
+def test_docker_save_doesnt_exist(path):
+    image_name = "idonotexistsurely"
+    if images_exist([image_name]):
+        raise SkipTest("Image wasn't supposed to exist, but does: {}"
+                       .format(image_name))
+    with assert_raises(CommandError):
+        call(["save", image_name, path])
+
+
+class TestAdapterBusyBox(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.image_name = "busybox:latest"
+        if images_exist([cls.image_name]):
+            cls.image_existed = True
+        else:
+            cls.image_existed = False
+            RUNNER.run(["docker", "pull", cls.image_name])
+
+    @classmethod
+    def teardown_class(cls):
+        if not cls.image_existed and images_exist([cls.image_name]):
+            RUNNER.run(["docker", "rmi", cls.image_name])
+
+    @with_tempfile(mkdir=True)
+    def test_save_and_run(self, path):
+        image_dir = op.join(path, "image")
+        call(["save", self.image_name, image_dir])
+        ok_exists(op.join(image_dir, "manifest.json"))
+        img_ids = list_images([self.image_name])
+        assert len(img_ids) == 1
+        eq_("sha256:" + da.get_image(image_dir),
+            img_ids[0])
+
+        if not self.image_existed:
+            RUNNER.run(["docker", "rmi", self.image_name])
+
+        out, _ = call(["run", image_dir, "ls"], cwd=path)
+
+        assert images_exist([self.image_name])
+        assert_in("image", out)
+
+    @with_tree({"foo": "content"})
+    def test_containers_run(self, path):
+        if self.image_existed:
+            raise SkipTest(
+                "Not pulling with containers-run due to existing image: {}"
+                .format(self.image_name))
+
+        from datalad.api import Dataset
+        ds = Dataset(path).create(force=True)
+        ds.save(path="foo")
+        ds.containers_add("bb", url="dhub://" + self.image_name)
+        with swallow_outputs() as out:
+            ds.containers_run(["cat", "foo"], container_name="bb")
+            assert_in("content", out.out)


### PR DESCRIPTION
Add some simple tests for the docker adapter that we can build on as we start to deal with some rough edges.  Hopefully my adjustment to .travis.yml is enough to make these run on Travis, but it might need additional tune-ups.


(I'm also sneaking in a commit that fixes calls to `logging.exception()`.)
