### PR TITLE
Be compatible with datalad 0.12.0rc6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ git:
   submodules: false
 
 python:
-  - 2.7
   - 3.5
   - 3.6
 

--- a/datalad_container/find_container.py
+++ b/datalad_container/find_container.py
@@ -25,7 +25,10 @@ def _get_container_by_name(_, name, containers):
 
 def _get_container_by_path(ds, name, containers):
     from datalad.distribution.dataset import resolve_path
-    container_path = resolve_path(name, ds)
+    # Note: since datalad0.12.0rc6 resolve_path returns a Path object here,
+    #       which then fails to equal c['path'] below as this is taken from
+    #       config as a string
+    container_path = str(resolve_path(name, ds))
     container = [c for c in containers.values()
                  if c['path'] == container_path]
     if len(container) == 1:

--- a/datalad_container/find_container.py
+++ b/datalad_container/find_container.py
@@ -38,7 +38,7 @@ def _get_container_by_path(ds, name, containers):
 # Entry point
 
 
-def find_container(ds, container_name):
+def find_container(ds, container_name=None):
     """Find the container in dataset `ds` specified by `container_name`.
 
     Parameters

--- a/datalad_container/tests/test_find.py
+++ b/datalad_container/tests/test_find.py
@@ -1,0 +1,38 @@
+import os.path as op
+from datalad.api import Dataset
+from datalad.tests.utils import (
+    ok_clean_git,
+    assert_in,
+    assert_is_instance,
+    assert_in_results,
+    assert_result_count,
+    assert_raises
+)
+from datalad.tests.utils import with_tree
+from datalad_container.find_container import find_container
+
+
+@with_tree(tree={"sub": {"i.img": "doesn't matter"}})
+def test_find_containers(path):
+    ds = Dataset(path).create(force=True)
+    ds.save(path=[op.join('sub', 'i.img')], message="dummy container")
+    ds.containers_add("i", image=op.join('sub', 'i.img'))
+    ok_clean_git(path)
+
+    # find the only one
+    res = find_container(ds)
+    assert_is_instance(res, dict)
+    assert_result_count([res], 1, status="ok", path=op.join(ds.path, "sub", "i.img"))
+
+    # find by name
+    res = find_container(ds, "i")
+    assert_is_instance(res, dict)
+    assert_result_count([res], 1, status="ok", path=op.join(ds.path, "sub", "i.img"))
+
+    # find by path
+    res = find_container(ds, op.join("sub", "i.img"))
+    assert_is_instance(res, dict)
+    assert_result_count([res], 1, status="ok", path=op.join(ds.path, "sub", "i.img"))
+
+    # don't find another thing
+    assert_raises(ValueError, find_container, ds, "nothere")


### PR DESCRIPTION
- Closes #108 
- add test for `find_container`, since it's absence is why we missed the failure in datalad's extension tests
- stumbled upon and fixed a minor bug in `find_container`: We implemented to just return the only container we found if no name was provided (and there's only one indeed), but `container_name` was a mandatory parameter, rendering that functionality pointless