### PR TITLE
BF: docker adapter: Drop -it flags when stdin is not a tty

### DIFF
--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -131,8 +131,10 @@ def cli_run(namespace):
               # dataset without the user needing to manually adjust the
               # permissions.
               "-u", "{}:{}".format(os.getuid(), os.getgid()),
-              "-it", "--rm",
-              image_id]
+              "--rm"]
+    if sys.stdin.isatty():
+        prefix.append("-it")
+    prefix.append(image_id)
     cmd = prefix + namespace.cmd
     lgr.debug("Running %r", cmd)
     sp.check_call(cmd)


### PR DESCRIPTION
If stdin is not an interactive stream, executing `docker run` with
--interactive and --tty will fail with "the input device is not a
TTY", as happens on the GitHub Action build for the latest
datalad-container release [*].

Closes #112.

[*]: https://github.com/datalad/datalad/pull/3860/checks?check_run_id=294971073

---

I'll start a scratch PR on datalad's end to trigger a GitHub action with this change.