### PR TITLE
DOC: basic demo: Update stale statement about Docker support

### DIFF
--- a/docs/examples/basic_demo.sh
+++ b/docs/examples/basic_demo.sh
@@ -47,9 +47,8 @@ datalad containers-run cp /etc/debian_version proof.txt
 # is being executed, or which local directories shall be made available to
 # a container.
 #
-# At the moment there is built-in support for Singularity images, but other
+# At the moment there is built-in support for Singularity and Docker, but other
 # container execution systems can be used together with custom helper scripts.
-# Direct support for Docker is under development.
 #% EXAMPLE END
 
 testEquality() {


### PR DESCRIPTION
When that was written, the docker adapter wasn't available.  It's now
in the main source tree and is wired up to containers-add.

Re: https://github.com/datalad-handbook/book/pull/242#discussion_r353793791