### PR TITLE
RF: run: Filter eval_params from inherited parameters

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -13,6 +13,7 @@ from datalad.distribution.dataset import datasetmethod
 from datalad.distribution.dataset import require_dataset
 from datalad.interface.utils import eval_results
 
+from datalad.interface.common_opts import eval_params
 from datalad.interface.results import get_status_dict
 from datalad.interface.run import Run
 from datalad.interface.run import run_command
@@ -28,7 +29,7 @@ lgr = logging.getLogger("datalad.containers.containers_run")
 CONTAINER_NAME_ENVVAR = 'DATALAD_CONTAINER_NAME'
 
 _run_params = dict(
-    Run._params_,
+    {k: v for k, v in Run._params_.items() if k not in eval_params},
     container_name=Parameter(
         args=('-n', '--container-name',),
         metavar="NAME",


### PR DESCRIPTION
```
containers-run builds ContainersRun._params_ from Run._params_ to
extend run's interface with container-specific parameters.  However,
this is unintentionally populating ContainersRun._params_ with
parameters from eval_params because build_doc() modifies Run._params_
in place.

Having eval_param keys in ContainersRun._params_ doesn't currently
cause any issues because build_doc() does a blanket update of _params_
with eval_params, but a proposed change to build_doc() exposed the
issue (datalad/datalad#4480).  That patch will likely be rewritten in
a way that doesn't trigger the issue, but, in hopes of avoiding
similar issues in the future, let's rework ContainersRun handling to
not depend on internal details of how build_doc() works.
```

Ref: datalad/datalad#4480