### PR TITLE
RF: use datalad.core.local.run instead of datalad.interface.run

### DIFF
--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -14,10 +14,12 @@ from datalad.distribution.dataset import require_dataset
 from datalad.interface.utils import eval_results
 
 from datalad.interface.results import get_status_dict
-from datalad.interface.run import Run
-from datalad.interface.run import run_command
-from datalad.interface.run import get_command_pwds
-from datalad.interface.run import normalize_command
+from datalad.core.local.run import (
+    Run,
+    get_command_pwds,
+    normalize_command,
+    run_command,
+)
 from datalad_container.find_container import find_container
 
 lgr = logging.getLogger("datalad.containers.containers_run")


### PR DESCRIPTION
datalad.interface.run was announced deprecated in 0.12, and likely will be
removed in 0.13.  We already depend on datalad >= 0.12 so should be good to
go.

We should really look into establishing nice deprecation annotation/workflow
so our extensions tests would run with failures if they use deprecated interfaces
while already depending on recent versions