### PR TITLE
Let DataLad handle shub:// when capable

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -29,11 +29,23 @@ from .definitions import definitions
 
 lgr = logging.getLogger("datalad.containers.containers_add")
 
+# The DataLad special remote has built-in support for Singularity Hub URLs. Let
+# it handle shub:// URLs if it's available.
+_HAS_SHUB_DOWNLOADER = True
+try:
+    import datalad.downloaders.shub
+except ImportError:
+    lgr.debug("DataLad's shub downloader not found. "
+              "Custom handling for shub:// will be used")
+    _HAS_SHUB_DOWNLOADER = False
+
 
 def _resolve_img_url(url):
     """Takes a URL and tries to resolve it to an actual download
     URL that `annex addurl` can handle"""
-    if url.startswith('shub://'):
+    if not _HAS_SHUB_DOWNLOADER and url.startswith('shub://'):
+        # TODO: Remove this handling once the minimum DataLad version is at
+        # least 0.14.
         lgr.debug('Query singularity-hub for image download URL')
         import requests
         req = requests.get(
@@ -57,6 +69,28 @@ def _guess_call_fmt(ds, name, url):
         return 'singularity exec {img} {cmd}'
     elif url.startswith('dhub://'):
         return op.basename(sys.executable) + ' -m datalad_container.adapters.docker run {img} {cmd}'
+
+
+def _ensure_datalad_remote(repo):
+    """Initialize and enable datalad special remote if it isn't already."""
+    dl_remote = None
+    for info in repo.get_special_remotes().values():
+        if info["externaltype"] == "datalad":
+            dl_remote = info["name"]
+            break
+
+    if not dl_remote:
+        from datalad.consts import DATALAD_SPECIAL_REMOTE
+        from datalad.customremotes.base import init_datalad_remote
+
+        init_datalad_remote(repo, DATALAD_SPECIAL_REMOTE, autoenable=True)
+    elif repo.is_special_annex_remote(dl_remote, check_if_known=False):
+        lgr.debug("datalad special remote '%s' is already enabled",
+                  dl_remote)
+    else:
+        lgr.debug("datalad special remote '%s' found. Enabling",
+                  dl_remote)
+        repo.enable_remote(dl_remote)
 
 
 @build_doc
@@ -251,6 +285,9 @@ class ContainersAdd(Interface):
                     os.makedirs(image_dir)
                 copyfile(url, image)
             else:
+                if _HAS_SHUB_DOWNLOADER and url.startswith('shub://'):
+                    _ensure_datalad_remote(ds.repo)
+
                 try:
                     ds.repo.add_url_to_file(image, imgurl)
                 except Exception as e:

--- a/datalad_container/tests/test_add.py
+++ b/datalad_container/tests/test_add.py
@@ -1,0 +1,43 @@
+from datalad.api import Dataset
+from datalad.api import clone
+from datalad.consts import DATALAD_SPECIAL_REMOTE
+from datalad.customremotes.base import init_datalad_remote
+from datalad.tests.utils import assert_false
+from datalad.tests.utils import assert_in
+from datalad.tests.utils import assert_not_in
+from datalad.tests.utils import with_tempfile
+from datalad.utils import Path
+
+from datalad_container.containers_add import _ensure_datalad_remote
+
+# NOTE: At the moment, testing of the containers-add itself happens implicitly
+# via use in other tests.
+
+
+@with_tempfile
+def test_ensure_datalad_remote_init_and_enable_needed(path):
+    ds = Dataset(path).create(force=True)
+    repo = ds.repo
+    assert_false(repo.get_remotes())
+    _ensure_datalad_remote(repo)
+    assert_in("datalad", repo.get_remotes())
+
+
+@with_tempfile
+def check_ensure_datalad_remote_maybe_enable(autoenable, path):
+    path = Path(path)
+    ds_a = Dataset(path / "a").create(force=True)
+    init_datalad_remote(ds_a.repo, DATALAD_SPECIAL_REMOTE,
+                        autoenable=autoenable)
+
+    ds_b = clone(source=ds_a.path, path=path / "b")
+    repo = ds_b.repo
+    if not autoenable:
+        assert_not_in("datalad", repo.get_remotes())
+    _ensure_datalad_remote(repo)
+    assert_in("datalad", repo.get_remotes())
+
+
+def test_ensure_datalad_remote_maybe_enable():
+    yield check_ensure_datalad_remote_maybe_enable, False
+    yield check_ensure_datalad_remote_maybe_enable, True

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -87,8 +87,7 @@ def test_container_files(path, super_path):
     assert_result_count(
         ds.containers_list(), 1,
         path=op.join(ds.path, 'righthere'),
-        name='mycontainer',
-        updateurl=testimg_url)
+        name='mycontainer')
     ok_clean_git(path)
 
     def assert_no_change(res, path):

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -186,7 +186,7 @@ def test_custom_call_fmt(path, local_file):
 def test_run_no_explicit_dataset(path):
     raise SkipTest('SingularityHub is gone for now')
     ds = Dataset(path).create(force=True)
-    ds.add(".")
+    ds.save()
     ds.containers_add("deb", url=testimg_url,
                       call_fmt="singularity exec {img} {cmd}")
 


### PR DESCRIPTION
datalad/datalad#4816 added support for `shub://` URLs within the DataLad special remote.  This PR adjusts `containers-add` to go through that when it's available.

- [X] Drop tip commit that temporarily enables tests that use Singularity Hub.
  
  Update: That build looks fine.  The failure in both jobs is the known and unresolved issue from gh-126.

  https://travis-ci.org/github/datalad/datalad-container/builds/729717666