### PR TITLE
MNT: Drop bound method imports

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -22,9 +22,6 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.interface.results import get_status_dict
 
-# required bound commands
-from datalad.coreapi import save
-
 from .definitions import definitions
 
 lgr = logging.getLogger("datalad.containers.containers_add")

--- a/datalad_container/containers_remove.py
+++ b/datalad_container/containers_remove.py
@@ -15,11 +15,6 @@ from datalad.support.constraints import EnsureNone
 from datalad.support.constraints import EnsureStr
 from datalad.interface.results import get_status_dict
 
-# required bound methods
-from datalad.coreapi import save
-from datalad.coreapi import remove
-
-
 lgr = logging.getLogger("datalad.containers.containers_remove")
 
 


### PR DESCRIPTION
These haven't been needed since DataLad v0.11.3.  (The current minimum
version is 0.12.)