### PR TITLE
TEMP: set log level to debug and log outputs, limit to failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,14 @@ env:
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
-    - TESTS_TO_PERFORM=
+    - TESTS_TO_PERFORM=datalad_container/tests/test_schemes.py:test_docker 
     - NOSE_OPTS=-s
     - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
+    - DATALAD_LOG_LEVEL=debug
+    - DATALAD_LOG_OUTPUTS=1
   matrix:
     - DATALAD_REPO_VERSION=5
     - DATALAD_REPO_VERSION=6

--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -63,7 +63,7 @@ def _guess_call_fmt(ds, name, url):
     if url is None:
         return None
     elif url.startswith('shub://') or url.startswith('docker://'):
-        return 'singularity exec {img} {cmd}'
+        return 'singularity --debug exec {img} {cmd}'
     elif url.startswith('dhub://'):
         return op.basename(sys.executable) + ' -m datalad_container.adapters.docker run {img} {cmd}'
 

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -187,7 +187,7 @@ def test_run_no_explicit_dataset(path):
     ds = Dataset(path).create(force=True)
     ds.save()
     ds.containers_add("deb", url=testimg_url,
-                      call_fmt="singularity exec {img} {cmd}")
+                      call_fmt="singularity --debug exec {img} {cmd}")
 
     # When no explicit dataset is given, paths are interpreted as relative to
     # the current working directory.

--- a/datalad_container/tests/test_schemes.py
+++ b/datalad_container/tests/test_schemes.py
@@ -27,5 +27,4 @@ def test_docker(path):  # Singularity's "docker://" scheme.
     assert_result_count(ds.containers_list(), 1, path=img, name="bb")
     ok_clean_git(path)
 
-    with swallow_outputs():
-        ds.containers_run(["ls", "/singularity"])
+    ds.containers_run(["ls", "/singularity"])


### PR DESCRIPTION
to see if more information comes up about failing docker/singularity run

ref: #126 