### PR TITLE
RF: Adjust test to accomodate for no-log behavior of `run`

### DIFF
--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -17,7 +17,6 @@ from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import with_tempfile
 from datalad.tests.utils import with_tree
 from datalad.tests.utils import skip_if_no_network
-from datalad.tests.utils import swallow_outputs
 from datalad.tests.utils import SkipTest
 from datalad.utils import (
     chpwd,

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -167,13 +167,13 @@ def test_custom_call_fmt(path, local_file):
 
     # Running should work fine either withing sub or within super
     out = WitlessRunner(cwd=subds.path).run(
-        'datalad containers-run -n mycontainer XXX',
+        ['datalad', 'containers-run', '-n', 'mycontainer', 'XXX'],
         protocol=StdOutCapture)
     assert_in('image=righthere cmd=XXX img_dspath=. name=mycontainer',
               out['stdout'])
 
     out = WitlessRunner(cwd=ds.path).run(
-        'datalad containers-run -n sub/mycontainer XXX',
+        ['datalad', 'containers-run', '-n', 'sub/mycontainer', 'XXX'],
         protocol=StdOutCapture)
     assert_in('image=sub/righthere cmd=XXX img_dspath=sub', out['stdout'])
 
@@ -181,7 +181,7 @@ def test_custom_call_fmt(path, local_file):
     subdir = op.join(ds.path, 'subdir')
     os.mkdir(subdir)
     out = WitlessRunner(cwd=subdir).run(
-        'datalad containers-run -n sub/mycontainer XXX',
+        ['datalad', 'containers-run', '-n', 'sub/mycontainer', 'XXX'],
         protocol=StdOutCapture)
     assert_in('image=../sub/righthere cmd=XXX img_dspath=../sub', out['stdout'])
 

--- a/datalad_container/tests/test_schemes.py
+++ b/datalad_container/tests/test_schemes.py
@@ -5,8 +5,11 @@ from datalad.api import create
 from datalad.api import containers_add
 from datalad.api import containers_list
 from datalad.api import containers_run
-
-from datalad.utils import swallow_outputs
+from datalad.cmd import (
+    Runner,
+    StdOutCapture,
+    WitlessRunner,
+)
 from datalad.tests.utils import ok_clean_git
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import assert_result_count
@@ -27,5 +30,6 @@ def test_docker(path):  # Singularity's "docker://" scheme.
     assert_result_count(ds.containers_list(), 1, path=img, name="bb")
     ok_clean_git(path)
 
-    with swallow_outputs():
-        ds.containers_run(["ls", "/singularity"])
+    WitlessRunner(cwd=ds.path).run(
+        ["datalad", "containers-run", "ls", "/singularity"],
+        protocol=StdOutCapture)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ except (ImportError, OSError) as exc:
 
 requires = {
     'core': [
-        'datalad>=0.12',
+        'datalad>=0.13',
         'requests>=1.2',  # to talk to Singularity-hub
         'mock',   # used in containers_run
     ],


### PR DESCRIPTION
Introduced by https://github.com/datalad/datalad/pull/4996