### PR TITLE
WIN/BF: When on Windows, close temporary files for further use

### DIFF
--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -44,6 +44,8 @@ def save(image, path):
     # Use a temporary file because docker save (or actually tar underneath)
     # complains that stdout needs to be redirected if we use Popen and PIPE.
     with tempfile.NamedTemporaryFile() as stream:
+        # Windows can't write to an already opened file
+        stream.close()
         sp.check_call(["docker", "save", "-o", stream.name, image])
         with tarfile.open(stream.name, mode="r:") as tar:
             if not op.exists(path):


### PR DESCRIPTION
I tried to put my explorations from https://github.com/datalad/datalad/issues/5138 into a PR. Running tests locally on Windows is a potpourri of errors, so pushed this hoping that the CI catches everything that I might have broken with this for other operating systems ;-)   