### PR TITLE
BF: docker adapter: Don't couple 'run -i' with stdin.isatty

### DIFF
--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -133,7 +133,8 @@ def cli_run(namespace):
               # should be configurable.
               "-v", "{}:/tmp".format(os.getcwd()),
               "-w", "/tmp",
-              "--rm"]
+              "--rm",
+              "--interactive"]
     if not on_windows:
         # Make it possible for the output files to be added to the
         # dataset without the user needing to manually adjust the
@@ -141,7 +142,7 @@ def cli_run(namespace):
         prefix.extend(["-u", "{}:{}".format(os.getuid(), os.getgid())])
 
     if sys.stdin.isatty():
-        prefix.append("-it")
+        prefix.append("--tty")
     prefix.append(image_id)
     cmd = prefix + namespace.cmd
     lgr.debug("Running %r", cmd)

--- a/datalad_container/adapters/tests/test_docker.py
+++ b/datalad_container/adapters/tests/test_docker.py
@@ -99,3 +99,11 @@ class TestAdapterBusyBox(object):
             ["datalad", "containers-run", "-n", "bb", "cat foo"],
             protocol=StdOutCapture)
         assert_in("content", out["stdout"])
+
+        # Data can be received on stdin.
+        with (ds.pathobj / "foo").open() as ifh:
+            out = WitlessRunner(cwd=ds.path).run(
+                ["datalad", "containers-run", "-n", "bb", "cat"],
+                protocol=StdOutCapture,
+                stdin=ifh)
+        assert_in("content", out["stdout"])


### PR DESCRIPTION
24af27f9 (BF: docker adapter: Drop -it flags when stdin is not a tty,
2019-11-11) dropped both --interactive and --tty from the 'docker run'
call if stdin.isatty() reports false, avoiding an "the input device is
not a TTY" failure in this case.

However, dropping --interactive shouldn't be necessary, and doing so
prevents the command from receiving stdin.

---

I noticed this issue when looking into gh-123.

Before this PR:

```console
$ echo foo | md5sum
d3b07384d113edec49eaa6238ad5ff00  -
$ echo foo | datalad containers-run -n alp md5sum
[INFO] Making sure inputs are available (this may take some time)
[INFO] == Command start (output follows) =====
d41d8cd98f00b204e9800998ecf8427e  -
[INFO] == Command exit (modification check follows) =====
[INFO] Total: starting
[INFO]
[INFO] Total: processed result for /tmp/po-TYjIvuy
[INFO] Total: done
action summary:
  get (notneeded: 1)
  save (notneeded: 1)
```

After:

```console
$ echo foo | datalad containers-run -n alp md5sum
[INFO] Making sure inputs are available (this may take some time)
[INFO] == Command start (output follows) =====
d3b07384d113edec49eaa6238ad5ff00  -
[INFO] == Command exit (modification check follows) =====
[INFO] Total: starting
[INFO]
[INFO] Total: processed result for /tmp/po-TYjIvuy
[INFO] Total: done
action summary:
  get (notneeded: 1)
  save (notneeded: 1)
```
