### PR TITLE
TST: travis: Upgrade pip before installing datalad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_install:
   - travis_retry sudo eatmydata apt-get install --no-install-recommends git-annex-standalone aria2 git-remote-gcrypt lsof gnupg nocache
   # chroot/container stuff
   - travis_retry sudo eatmydata apt-get install xz-utils singularity-container
+  - pip install --upgrade pip
 
 
 install:


### PR DESCRIPTION
The latest -container builds have widespread failures, presumably all
related to this:

    [WARNING] Failed to load entrypoint container: (requests 2.25.0
    (/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages),
    Requirement.parse('requests<2.25,>=2.14.0'), {'PyGithub'})
    [__init__.py:resolve:789]

Follow the same approach as datalad's 6c98c33511 (2020-12-01,
datalad/datalad#5188), and upgrade to the latest pip, which enables a
new dependency resolver by default.

https://travis-ci.com/github/datalad/datalad-container/jobs/453928112#L1014