### PR TITLE
TST: docker_adapter: Skip tests if 'docker pull' in setup fails

### DIFF
--- a/datalad_container/adapters/tests/test_docker.py
+++ b/datalad_container/adapters/tests/test_docker.py
@@ -57,7 +57,11 @@ class TestAdapterBusyBox(object):
             cls.image_existed = True
         else:
             cls.image_existed = False
-            WitlessRunner().run(["docker", "pull", cls.image_name])
+            try:
+                WitlessRunner().run(["docker", "pull", cls.image_name])
+            except CommandError:
+                # This is probably due to rate limiting.
+                raise SkipTest("Plain `docker pull` failed; skipping")
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
TestAdapterBusyBox.setup_class() calls 'docker pull' to bring in the
busybox image.  If this fails [1], it's probably due to rate limiting.
Regardless this is a plain 'docker pull' that doesn't involve any
parts of -container, so it's an indication that the system isn't
capable of carrying out these tests.

[1]: For example:
     https://github.com/datalad/datalad/pull/5404/checks?check_run_id=1824553695