### PR TITLE
Set up workflow with auto for releasing & PyPI uploads

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,7 @@
+{
+    "onlyPublishWithReleaseLabel": true,
+    "baseBranch": "master",
+    "author": "auto <auto@nil>",
+    "noVersionPrefix": true,
+    "plugins": ["git-tag"]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Auto-release on PR merge
+
+on:
+  # ATM, this is the closest trigger to a PR merging
+  push:
+    branches:
+      - master
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    outputs:
+      auto-version: ${{ steps.auto-version.outputs.version }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download latest auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
+
+      - name: Check whether a release is due
+        id: auto-version
+        run: |
+          version="$(~/auto version)"
+          echo "::set-output name=version::$version"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        run: ~/auto shipit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pypi:
+    runs-on: ubuntu-latest
+    needs: auto-release
+    if: "needs.auto-release.outputs.auto-version != ''"
+    steps:
+      # By default, actions/checkout will checkout the commit that that was
+      # pushed to master and triggered the workflow, but this does not include
+      # the commit & tag created by `auto`.  In order to get that, we need to
+      # look up the tag for the latest release.
+      - name: Get tag of latest release
+        id: latest-release
+        run: |
+          latest_tag="$(curl -fsSL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r .tag_name)"
+          echo "::set-output name=tag::$latest_tag"
+
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.latest-release.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - name: Install build & twine
+        run: python -m pip install build twine
+
+      - name: Build
+        run: python -m build
+
+      - name: Upload
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+# vim:set et sts=2:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,14 @@
-     ____          _           _                 _ 
-    |  _ \   __ _ | |_   __ _ | |      __ _   __| |
-    | | | | / _` || __| / _` || |     / _` | / _` |
-    | |_| || (_| || |_ | (_| || |___ | (_| || (_| |
-    |____/  \__,_| \__| \__,_||_____| \__,_| \__,_|
-                                          Container
-
-This is a high level and scarce summary of the changes between releases.  We
-would recommend to consult log of the [DataLad git
-repository](http://github.com/datalad/datalad-container) for more details.
-
-## 1.1.2 (January 16, 2021) --
+# 1.1.2 (January 16, 2021) --
 
 - Replace use of `mock` with `unittest.mock` as we do no longer support
   Python 2
 
-## 1.1.1 (January 03, 2021) --
+# 1.1.1 (January 03, 2021) --
 
 - Drop use of `Runner` (to be removed in datalad 0.14.0) in favor of
   `WitlessRunner`
 
-## 1.1.0 (October 30, 2020) -- 
+# 1.1.0 (October 30, 2020) -- 
 
 - Datalad version 0.13.0 or later is now required.
 
@@ -34,20 +23,20 @@ repository](http://github.com/datalad/datalad-container) for more details.
   to execute a container from underneath an uninstalled subdataset.
 
 
-## 1.0.1 (June 23, 2020) -- 
+# 1.0.1 (June 23, 2020) -- 
 
 - Prefer `datalad.core.local.run` to `datalad.interface.run`.  The
   latter has been marked as obsolete since DataLad v0.12 (our minimum
   requirement) and will be removed in DataLad's next feature release.
 
-## 1.0.0 (Feb 23, 2020) -- not-as-a-shy-one
+# 1.0.0 (Feb 23, 2020) -- not-as-a-shy-one
 
 Extension is pretty stable so releasing as 1. MAJOR release, so we could
 start tracking API breakages and enhancements properly.
 
 - Drops support for Python 2 and DataLad prior 0.12
 
-## 0.5.2 (Nov 12, 2019) --
+# 0.5.2 (Nov 12, 2019) --
 
 ### Fixes
 
@@ -55,7 +44,7 @@ start tracking API breakages and enhancements properly.
   `--interactive` and `--tty` even when stdin was not attached to a
   TTY, leading to an error.
 
-## 0.5.1 (Nov 08, 2019) --
+# 0.5.1 (Nov 08, 2019) --
 
 ### Fixes
 
@@ -66,7 +55,7 @@ start tracking API breakages and enhancements properly.
   value, which isn't true as of the latest DataLad release candidate,
   0.12.0rc6.
 
-## 0.5.0 (Jul 12, 2019) -- damn-you-malicious-users
+# 0.5.0 (Jul 12, 2019) -- damn-you-malicious-users
 
 ### New features
 
@@ -77,7 +66,7 @@ start tracking API breakages and enhancements properly.
 
 - Temporarily skip two tests relying on SingularityHub -- it is down.
 
-## 0.4.0 (May 29, 2019) -- run-baby-run
+# 0.4.0 (May 29, 2019) -- run-baby-run
 
 The minimum required DataLad version is now 0.11.5.
 
@@ -106,14 +95,14 @@ The minimum required DataLad version is now 0.11.5.
   doesn't yet exist, but it confusingly still used the word "update"
   in the commit message.
 
-## 0.3.1 (Mar 05, 2019) -- Upgrayeddd
+# 0.3.1 (Mar 05, 2019) -- Upgrayeddd
 
 ### Fixes
 
 - `containers-list` recursion actually does recursion.
 
 
-## 0.3.0 (Mar 05, 2019) -- Upgrayedd
+# 0.3.0 (Mar 05, 2019) -- Upgrayedd
 
 ### API changes
 
@@ -138,28 +127,28 @@ The minimum required DataLad version is now 0.11.5.
   now decides to look for containers in subdatasets based on whether
   the name has a slash (which is true of all subdataset containers).
 
-## 0.2.2 (Dec 19, 2018) -- The more the merrier
+# 0.2.2 (Dec 19, 2018) -- The more the merrier
 
 - list/use containers recursively from installed subdatasets
 - Allow to specify container by path rather than just by name
 - Adding a container from local filesystem will copy it now
 
-## 0.2.1 (Jul 14, 2018) -- Explicit lyrics
+# 0.2.1 (Jul 14, 2018) -- Explicit lyrics
 
 - Add support `datalad run --explicit`.
 
-## 0.2 (Jun 08, 2018) -- Docker
+# 0.2 (Jun 08, 2018) -- Docker
 
 - Initial support for adding and running Docker containers.
 - Add support `datalad run --sidecar`.
 - Simplify storage of `call_fmt` arguments in the Git config, by benefiting
   from `datalad run` being able to work with single-string compound commands.
 
-## 0.1.2 (May 28, 2018) -- The docs
+# 0.1.2 (May 28, 2018) -- The docs
 
 - Basic beginner documentation
 
-## 0.1.1 (May 22, 2018) -- The fixes
+# 0.1.1 (May 22, 2018) -- The fixes
 
 ### New features
 
@@ -176,7 +165,7 @@ The minimum required DataLad version is now 0.11.5.
 - Pass relative container path to `datalad run`.
 - `containers-run` no longer hides `datalad run` failures.
 
-## 0.1 (May 19, 2018) -- The Release
+# 0.1 (May 19, 2018) -- The Release
 
 - Initial release with basic functionality to add, remove, and list
   containers in a dataset, plus a `run` command wrapper that injects

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include formatters.py setup_support.py


### PR DESCRIPTION
Learning to do it by following @jwodder 's example in https://github.com/datalad/datalad-crawler/pull/86

Here we can even have a release now (1.1.2-16-geccfdf8) although probably auto could perform suboptimally since merged PRs were not properly labeled.  Could that be done "postmortem" (label PRs after they are already merged) to the desired effect @jwodder ?