### PR TITLE
BF:Docs: replace incorrect dashes with spaces in command names

### DIFF
--- a/formatters.py
+++ b/formatters.py
@@ -197,7 +197,7 @@ class RSTManPageFormatter(ManPageFormatter):
 
     def _mk_title(self, prog):
         # and an easy to use reference point
-        title = ".. _man_%s:\n\n" % prog
+        title = ".. _man_%s:\n\n" % prog.replace(' ', '-')
         title += "{0}".format(prog)
         title += '\n{0}\n\n'.format('=' * len(prog))
         return title

--- a/setup_support.py
+++ b/setup_support.py
@@ -100,12 +100,12 @@ class BuildManPage(Command):
             for cmdname in cmdline_command_names:
                 p = self._parser[cmdname]
                 cmdname = "{0}{1}".format(
-                    'datalad-' if cmdname != 'datalad' else '',
+                    'datalad ' if cmdname != 'datalad' else '',
                     cmdname)
                 format = cls(cmdname, ext_sections=sections, version=get_version())
                 formatted = format.format_man_page(p)
                 with open(opj(opath, '{0}.{1}'.format(
-                        cmdname,
+                        cmdname.replace(' ', '-'),
                         ext)),
                         'w') as f:
                     f.write(formatted)


### PR DESCRIPTION
The documentation for the commands contain dashes that should be spaces, ie:

`datalad-containers-run` should be `datalad containers-run`

This applies a fix that was made for other docs (datalad/datalad#1761).

(Closes #153)