### PR TITLE
BF: fix special remotes without "externaltype"

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -72,7 +72,7 @@ def _ensure_datalad_remote(repo):
     """Initialize and enable datalad special remote if it isn't already."""
     dl_remote = None
     for info in repo.get_special_remotes().values():
-        if info["externaltype"] == "datalad":
+        if info.get("externaltype") == "datalad":
             dl_remote = info["name"]
             break
 


### PR DESCRIPTION
As stated in #155, the change made in https://github.com/datalad/datalad-container/commit/c6068d657b8d1e8abb2d8e44e4cba71949d8b3f1 to `containers-add`, added a check to initialize and enable datalad special remote if it isn't already. If a special remote exists, but doesn't have "externaltype" configured, this check resulted in a KeyError. 

This change guards against "externaltype" not existing.

Fixes #155