### PR TITLE
BF: Disable subdataset result rendering

### DIFF
--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -61,7 +61,9 @@ class ContainersList(Interface):
         if recursive:
             for sub in ds.subdatasets(
                     contains=contains,
-                    on_failure='ignore', return_type='generator'):
+                    on_failure='ignore',
+                    return_type='generator',
+                    result_renderer='disabled'):
                 subds = Dataset(sub['path'])
                 if subds.is_installed():
                     for c in subds.containers_list(recursive=recursive,


### PR DESCRIPTION
Else, a datalad containers-run command will start by reporting
on all subdatasets in the dataset hierarchy (see #174).
This disables the result renderer in the spirit of
https://github.com/datalad/datalad/issues/6461

Fixes #174