### PR TITLE
Mention that could be installed from conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ a dedicated [virtualenv](https://virtualenv.pypa.io):
     # install from PyPi
     pip install datalad_container
 
+It is also available for conda package manager from conda-forge:
+
+    conda install -c conda-forge datalad-container
+
+
 ## Support
 
 The documentation of this project is found here:


### PR DESCRIPTION
but primary goal for this PR is to ensure that CI is still ok and release since currently we are still at 1.1.5-37-gf2c0396 and need a release to become compatible with datalad 0.16.0 which moved GitRepo.*modules methods to -deprecated