### PR TITLE
nose -> pytest, isort imports in tests, unify requirements-devel to correspond to the form as in core

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -192,10 +192,9 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-    # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_container %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_container ${DTS}
-
+  # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
+  - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_container --pyargs %DTS%
+  - sh:  python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_container --pyargs ${DTS}
 
 after_test:
   - python -m coverage xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ env:
     - BOTO_CONFIG=/tmp/nowhere
     - DATALAD_TESTS_SSH=1
     - DATALAD_LOG_CMD_ENV=GIT_SSH_COMMAND
-    - TESTS_TO_PERFORM=
-    - NOSE_OPTS=-s
-    - NOSE_SELECTION_OP="not "   # so it would be "not (integration or usecase)"
+    - TESTS_TO_PERFORM=datalad_container
+    - PYTEST_OPTS=-s
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
@@ -64,11 +63,11 @@ script:
   # Run tests
   - http_proxy=
     PATH=$PWD/tools/coverage-bin:$PATH
-    $NOSE_WRAPPER python -m nose $NOSE_OPTS
-      -v -A "$NOSE_SELECTION_OP(integration or usecase or slow)"
-      --with-doctest
-      --with-cov --cover-package datalad_container
-      --logging-level=INFO
+    pytest $PYTEST_OPTS
+      -v
+      --cov datalad_container
+      --log-cli-level=INFO
+      --pyargs
       $TESTS_TO_PERFORM
   # Report WTF information using system wide installed version
   - datalad wtf

--- a/datalad_container/__init__.py
+++ b/datalad_container/__init__.py
@@ -45,6 +45,3 @@ command_suite = (
         )
     ]
 )
-
-from datalad import setup_package
-from datalad import teardown_package

--- a/datalad_container/adapters/tests/test_docker.py
+++ b/datalad_container/adapters/tests/test_docker.py
@@ -1,8 +1,7 @@
-from distutils.spawn import find_executable
 import os.path as op
 import sys
+from distutils.spawn import find_executable
 
-import datalad_container.adapters.docker as da
 from datalad.cmd import (
     StdOutCapture,
     WitlessRunner,
@@ -17,6 +16,8 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
     with_tree,
 )
+
+import datalad_container.adapters.docker as da
 
 if not find_executable("docker"):
     raise SkipTest("'docker' not found on path")

--- a/datalad_container/adapters/tests/test_docker.py
+++ b/datalad_container/adapters/tests/test_docker.py
@@ -8,7 +8,7 @@ from datalad.cmd import (
     WitlessRunner,
 )
 from datalad.support.exceptions import CommandError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     SkipTest,
     assert_in,
     assert_raises,
@@ -39,7 +39,7 @@ def images_exist(args):
 
 
 @with_tempfile
-def test_docker_save_doesnt_exist(path):
+def test_docker_save_doesnt_exist(path=None):
     image_name = "idonotexistsurely"
     if images_exist([image_name]):
         raise SkipTest("Image wasn't supposed to exist, but does: {}"
@@ -69,7 +69,7 @@ class TestAdapterBusyBox(object):
             WitlessRunner().run(["docker", "rmi", cls.image_name])
 
     @with_tempfile(mkdir=True)
-    def test_save_and_run(self, path):
+    def test_save_and_run(self, path=None):
         image_dir = op.join(path, "image")
         call(["save", self.image_name, image_dir])
         ok_exists(op.join(image_dir, "manifest.json"))
@@ -88,7 +88,7 @@ class TestAdapterBusyBox(object):
         assert_in("image", out["stdout"])
 
     @with_tree({"foo": "content"})
-    def test_containers_run(self, path):
+    def test_containers_run(self, path=None):
         if self.image_existed:
             raise SkipTest(
                 "Not pulling with containers-run due to existing image: {}"

--- a/datalad_container/conftest.py
+++ b/datalad_container/conftest.py
@@ -1,0 +1,1 @@
+from datalad.conftest import setup_package

--- a/datalad_container/tests/test_add.py
+++ b/datalad_container/tests/test_add.py
@@ -2,20 +2,25 @@ from datalad.api import Dataset
 from datalad.api import clone
 from datalad.consts import DATALAD_SPECIAL_REMOTE
 from datalad.customremotes.base import init_datalad_remote
-from datalad.tests.utils import assert_false
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import with_tempfile
+
+from datalad.tests.utils_pytest import (
+    assert_false,
+    assert_in,
+    assert_not_in,
+    with_tempfile,
+)
 from datalad.utils import Path
 
 from datalad_container.containers_add import _ensure_datalad_remote
+
+import pytest
 
 # NOTE: At the moment, testing of the containers-add itself happens implicitly
 # via use in other tests.
 
 
 @with_tempfile
-def test_ensure_datalad_remote_init_and_enable_needed(path):
+def test_ensure_datalad_remote_init_and_enable_needed(path=None):
     ds = Dataset(path).create(force=True)
     repo = ds.repo
     assert_false(repo.get_remotes())
@@ -23,8 +28,9 @@ def test_ensure_datalad_remote_init_and_enable_needed(path):
     assert_in("datalad", repo.get_remotes())
 
 
+@pytest.mark.parametrize("autoenable", [False, True])
 @with_tempfile
-def check_ensure_datalad_remote_maybe_enable(autoenable, path):
+def test_ensure_datalad_remote_maybe_enable(path=None, *, autoenable):
     path = Path(path)
     ds_a = Dataset(path / "a").create(force=True)
     init_datalad_remote(ds_a.repo, DATALAD_SPECIAL_REMOTE,
@@ -36,8 +42,3 @@ def check_ensure_datalad_remote_maybe_enable(autoenable, path):
         assert_not_in("datalad", repo.get_remotes())
     _ensure_datalad_remote(repo)
     assert_in("datalad", repo.get_remotes())
-
-
-def test_ensure_datalad_remote_maybe_enable():
-    yield check_ensure_datalad_remote_maybe_enable, False
-    yield check_ensure_datalad_remote_maybe_enable, True

--- a/datalad_container/tests/test_add.py
+++ b/datalad_container/tests/test_add.py
@@ -1,8 +1,10 @@
-from datalad.api import Dataset
-from datalad.api import clone
+import pytest
+from datalad.api import (
+    Dataset,
+    clone,
+)
 from datalad.consts import DATALAD_SPECIAL_REMOTE
 from datalad.customremotes.base import init_datalad_remote
-
 from datalad.tests.utils_pytest import (
     assert_false,
     assert_in,
@@ -12,8 +14,6 @@ from datalad.tests.utils_pytest import (
 from datalad.utils import Path
 
 from datalad_container.containers_add import _ensure_datalad_remote
-
-import pytest
 
 # NOTE: At the moment, testing of the containers-add itself happens implicitly
 # via use in other tests.

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -1,28 +1,31 @@
 import os.path as op
 
-from datalad.api import Dataset
-from datalad.api import install
-from datalad.api import containers_add
-from datalad.api import containers_remove
-from datalad.api import containers_list
-
-from datalad.utils import swallow_outputs
-from datalad.tests.utils_pytest import SkipTest
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import with_tree
-from datalad.tests.utils_pytest import ok_
-from datalad.tests.utils_pytest import ok_file_has_content
-from datalad.tests.utils_pytest import assert_equal
-from datalad.tests.utils_pytest import assert_status
-from datalad.tests.utils_pytest import assert_raises
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import assert_in
-from datalad.tests.utils_pytest import assert_in_results
-from datalad.tests.utils_pytest import assert_not_in
-from datalad.tests.utils_pytest import assert_re_in
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import serve_path_via_http
+from datalad.api import (
+    Dataset,
+    containers_add,
+    containers_list,
+    containers_remove,
+    install,
+)
 from datalad.support.network import get_local_file_url
+from datalad.tests.utils_pytest import (
+    SkipTest,
+    assert_equal,
+    assert_in,
+    assert_in_results,
+    assert_not_in,
+    assert_raises,
+    assert_re_in,
+    assert_result_count,
+    assert_status,
+    ok_,
+    ok_clean_git,
+    ok_file_has_content,
+    serve_path_via_http,
+    with_tempfile,
+    with_tree,
+)
+from datalad.utils import swallow_outputs
 
 from datalad_container.tests.utils import add_pyscript_image
 

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -7,28 +7,28 @@ from datalad.api import containers_remove
 from datalad.api import containers_list
 
 from datalad.utils import swallow_outputs
-from datalad.tests.utils import SkipTest
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import ok_
-from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import assert_equal
-from datalad.tests.utils import assert_status
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_in_results
-from datalad.tests.utils import assert_not_in
-from datalad.tests.utils import assert_re_in
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import serve_path_via_http
+from datalad.tests.utils_pytest import SkipTest
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import with_tree
+from datalad.tests.utils_pytest import ok_
+from datalad.tests.utils_pytest import ok_file_has_content
+from datalad.tests.utils_pytest import assert_equal
+from datalad.tests.utils_pytest import assert_status
+from datalad.tests.utils_pytest import assert_raises
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import assert_in
+from datalad.tests.utils_pytest import assert_in_results
+from datalad.tests.utils_pytest import assert_not_in
+from datalad.tests.utils_pytest import assert_re_in
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import serve_path_via_http
 from datalad.support.network import get_local_file_url
 
 from datalad_container.tests.utils import add_pyscript_image
 
 
 @with_tempfile
-def test_add_noop(path):
+def test_add_noop(path=None):
     ds = Dataset(path).create()
     ok_clean_git(ds.path)
     assert_raises(TypeError, ds.containers_add)
@@ -55,7 +55,7 @@ def test_add_noop(path):
 @with_tempfile
 @with_tree(tree={"foo.img": "doesn't matter 0",
                  "bar.img": "doesn't matter 1"})
-def test_add_local_path(path, local_file):
+def test_add_local_path(path=None, local_file=None):
     ds = Dataset(path).create()
     res = ds.containers_add(name="foobert",
                             url=op.join(local_file, "foo.img"))
@@ -82,7 +82,7 @@ RAW_KWDS = dict(return_type='list',
 @with_tempfile
 @with_tree(tree={'some_container.img': "doesn't matter"})
 @serve_path_via_http
-def test_container_files(ds_path, local_file, url):
+def test_container_files(ds_path=None, local_file=None, url=None):
     # setup things to add
     #
     # Note: Since "adding" as a container doesn't actually call anything or use
@@ -133,7 +133,7 @@ def test_container_files(ds_path, local_file, url):
 @with_tree(tree={'foo.img': "foo",
                  'bar.img': "bar"})
 @serve_path_via_http
-def test_container_update(ds_path, local_file, url):
+def test_container_update(ds_path=None, local_file=None, url=None):
     url_foo = get_local_file_url(op.join(local_file, 'foo.img'))
     url_bar = get_local_file_url(op.join(local_file, 'bar.img'))
     img = op.join(".datalad", "environments", "foo", "image")
@@ -177,7 +177,7 @@ def test_container_update(ds_path, local_file, url):
 @with_tempfile
 @with_tempfile
 @with_tree(tree={'some_container.img': "doesn't matter"})
-def test_container_from_subdataset(ds_path, src_subds_path, local_file):
+def test_container_from_subdataset(ds_path=None, src_subds_path=None, local_file=None):
 
     # prepare a to-be subdataset with a registered container
     src_subds = Dataset(src_subds_path).create()
@@ -214,7 +214,7 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
     sub2 = ds.create("sub2")
     assert_result_count(ds.subdatasets(), 2, type="dataset")
     ds.uninstall("sub2", check=False)
-    from datalad.tests.utils import assert_false
+    from datalad.tests.utils_pytest import assert_false
     assert_false(sub2.is_installed())
 
     # same results as before, not crashing or somehow confused by a not present
@@ -241,7 +241,7 @@ def test_container_from_subdataset(ds_path, src_subds_path, local_file):
 
 
 @with_tempfile
-def test_list_contains(path):
+def test_list_contains(path=None):
     ds = Dataset(path).create()
     subds_a = ds.create("a")
     subds_b = ds.create("b")

--- a/datalad_container/tests/test_find.py
+++ b/datalad_container/tests/test_find.py
@@ -1,6 +1,6 @@
 import os.path as op
 from datalad.api import Dataset
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     ok_clean_git,
     assert_in,
     assert_is_instance,
@@ -8,12 +8,12 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_raises
 )
-from datalad.tests.utils import with_tree
+from datalad.tests.utils_pytest import with_tree
 from datalad_container.find_container import find_container
 
 
 @with_tree(tree={"sub": {"i.img": "doesn't matter"}})
-def test_find_containers(path):
+def test_find_containers(path=None):
     ds = Dataset(path).create(force=True)
     ds.save(path=[op.join('sub', 'i.img')], message="dummy container")
     ds.containers_add("i", image=op.join('sub', 'i.img'))

--- a/datalad_container/tests/test_find.py
+++ b/datalad_container/tests/test_find.py
@@ -1,14 +1,16 @@
 import os.path as op
+
 from datalad.api import Dataset
 from datalad.tests.utils_pytest import (
-    ok_clean_git,
     assert_in,
-    assert_is_instance,
     assert_in_results,
+    assert_is_instance,
+    assert_raises,
     assert_result_count,
-    assert_raises
+    ok_clean_git,
+    with_tree,
 )
-from datalad.tests.utils_pytest import with_tree
+
 from datalad_container.find_container import find_container
 
 

--- a/datalad_container/tests/test_register.py
+++ b/datalad_container/tests/test_register.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import assert_result_count
+from datalad.tests.utils_pytest import assert_result_count
 
 
 def test_register():

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -9,18 +9,18 @@ from datalad.api import containers_run
 from datalad.api import containers_list
 
 from datalad.utils import Path
-from datalad.tests.utils import ok_
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import assert_false
-from datalad.tests.utils import assert_not_in_results
-from datalad.tests.utils import assert_in
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import assert_raises
-from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import with_tree
-from datalad.tests.utils import skip_if_no_network
-from datalad.tests.utils import SkipTest
+from datalad.tests.utils_pytest import ok_
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import assert_false
+from datalad.tests.utils_pytest import assert_not_in_results
+from datalad.tests.utils_pytest import assert_in
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import assert_raises
+from datalad.tests.utils_pytest import ok_file_has_content
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import with_tree
+from datalad.tests.utils_pytest import skip_if_no_network
+from datalad.tests.utils_pytest import SkipTest
 from datalad.utils import (
     chpwd,
     on_windows,
@@ -38,7 +38,7 @@ testimg_url = 'shub://datalad/datalad-container:testhelper'
 
 @with_tree(tree={"dummy0.img": "doesn't matter 0",
                  "dummy1.img": "doesn't matter 1"})
-def test_run_mispecified(path):
+def test_run_mispecified(path=None):
     ds = Dataset(path).create(force=True)
     ds.save(path=["dummy0.img", "dummy1.img"])
     ok_clean_git(path)
@@ -46,7 +46,7 @@ def test_run_mispecified(path):
     # Abort if no containers exist.
     with assert_raises(ValueError) as cm:
         ds.containers_run("doesn't matter")
-    assert_in("No known containers", str(cm.exception))
+    assert_in("No known containers", str(cm.value))
 
     # Abort if more than one container exists but no container name is
     # specified.
@@ -55,16 +55,16 @@ def test_run_mispecified(path):
 
     with assert_raises(ValueError) as cm:
         ds.containers_run("doesn't matter")
-    assert_in("explicitly specify container", str(cm.exception))
+    assert_in("explicitly specify container", str(cm.value))
 
     # Abort if unknown container is specified.
     with assert_raises(ValueError) as cm:
         ds.containers_run("doesn't matter", container_name="ghost")
-    assert_in("Container selection impossible", str(cm.exception))
+    assert_in("Container selection impossible", str(cm.value))
 
 
 @with_tree(tree={"i.img": "doesn't matter"})
-def test_run_unknown_cmdexec_placeholder(path):
+def test_run_unknown_cmdexec_placeholder(path=None):
     ds = Dataset(path).create(force=True)
     ds.containers_add("i", image="i.img", call_fmt="{youdontknowme}")
     assert_result_count(
@@ -78,7 +78,7 @@ def test_run_unknown_cmdexec_placeholder(path):
 @skip_if_no_network
 @with_tempfile
 @with_tempfile
-def test_container_files(path, super_path):
+def test_container_files(path=None, super_path=None):
     raise SkipTest('SingularityHub is gone for now')
     ds = Dataset(path).create()
     cmd = ['dir'] if on_windows else ['ls']
@@ -154,7 +154,7 @@ def test_container_files(path, super_path):
 
 @with_tempfile
 @with_tree(tree={'some_container.img': "doesn't matter"})
-def test_custom_call_fmt(path, local_file):
+def test_custom_call_fmt(path=None, local_file=None):
     ds = Dataset(path).create()
     subds = ds.create('sub')
 
@@ -192,7 +192,7 @@ def test_custom_call_fmt(path, local_file):
 
 @skip_if_no_network
 @with_tree(tree={"subdir": {"in": "innards"}})
-def test_run_no_explicit_dataset(path):
+def test_run_no_explicit_dataset(path=None):
     raise SkipTest('SingularityHub is gone for now')
     ds = Dataset(path).create(force=True)
     ds.save()
@@ -218,7 +218,7 @@ def test_run_no_explicit_dataset(path):
 
 
 @with_tempfile
-def test_run_subdataset_install(path):
+def test_run_subdataset_install(path=None):
     path = Path(path)
     ds_src = Dataset(path / "src").create()
     # Repository setup

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -1,34 +1,37 @@
 import os
 import os.path as op
 
-from datalad.api import Dataset
-from datalad.api import clone
-from datalad.api import create
-from datalad.api import containers_add
-from datalad.api import containers_run
-from datalad.api import containers_list
-
-from datalad.utils import Path
-from datalad.tests.utils_pytest import ok_
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import assert_false
-from datalad.tests.utils_pytest import assert_not_in_results
-from datalad.tests.utils_pytest import assert_in
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import assert_raises
-from datalad.tests.utils_pytest import ok_file_has_content
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import with_tree
-from datalad.tests.utils_pytest import skip_if_no_network
-from datalad.tests.utils_pytest import SkipTest
-from datalad.utils import (
-    chpwd,
-    on_windows,
+from datalad.api import (
+    Dataset,
+    clone,
+    containers_add,
+    containers_list,
+    containers_run,
+    create,
 )
-from datalad.support.network import get_local_file_url
 from datalad.cmd import (
     StdOutCapture,
     WitlessRunner,
+)
+from datalad.support.network import get_local_file_url
+from datalad.tests.utils_pytest import (
+    SkipTest,
+    assert_false,
+    assert_in,
+    assert_not_in_results,
+    assert_raises,
+    assert_result_count,
+    ok_,
+    ok_clean_git,
+    ok_file_has_content,
+    skip_if_no_network,
+    with_tempfile,
+    with_tree,
+)
+from datalad.utils import (
+    Path,
+    chpwd,
+    on_windows,
 )
 
 from datalad_container.tests.utils import add_pyscript_image

--- a/datalad_container/tests/test_schemes.py
+++ b/datalad_container/tests/test_schemes.py
@@ -9,16 +9,16 @@ from datalad.cmd import (
     StdOutCapture,
     WitlessRunner,
 )
-from datalad.tests.utils import ok_clean_git
-from datalad.tests.utils import ok_file_has_content
-from datalad.tests.utils import assert_result_count
-from datalad.tests.utils import with_tempfile
-from datalad.tests.utils import skip_if_no_network
+from datalad.tests.utils_pytest import ok_clean_git
+from datalad.tests.utils_pytest import ok_file_has_content
+from datalad.tests.utils_pytest import assert_result_count
+from datalad.tests.utils_pytest import with_tempfile
+from datalad.tests.utils_pytest import skip_if_no_network
 
 
 @skip_if_no_network
 @with_tempfile
-def test_docker(path):  # Singularity's "docker://" scheme.
+def test_docker(path=None):  # Singularity's "docker://" scheme.
     ds = Dataset(path).create()
     ds.containers_add(
         "bb",

--- a/datalad_container/tests/test_schemes.py
+++ b/datalad_container/tests/test_schemes.py
@@ -1,19 +1,23 @@
 import os.path as op
 
-from datalad.api import Dataset
-from datalad.api import create
-from datalad.api import containers_add
-from datalad.api import containers_list
-from datalad.api import containers_run
+from datalad.api import (
+    Dataset,
+    containers_add,
+    containers_list,
+    containers_run,
+    create,
+)
 from datalad.cmd import (
     StdOutCapture,
     WitlessRunner,
 )
-from datalad.tests.utils_pytest import ok_clean_git
-from datalad.tests.utils_pytest import ok_file_has_content
-from datalad.tests.utils_pytest import assert_result_count
-from datalad.tests.utils_pytest import with_tempfile
-from datalad.tests.utils_pytest import skip_if_no_network
+from datalad.tests.utils_pytest import (
+    assert_result_count,
+    ok_clean_git,
+    ok_file_has_content,
+    skip_if_no_network,
+    with_tempfile,
+)
 
 
 @skip_if_no_network

--- a/datalad_container/tests/utils.py
+++ b/datalad_container/tests/utils.py
@@ -4,7 +4,7 @@ import sys
 
 from datalad.api import containers_add
 from datalad.utils import chpwd
-from datalad.tests.utils import SkipTest
+from datalad.tests.utils_pytest import SkipTest
 from datalad.interface.common_cfg import dirs as appdirs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
 requires = ["setuptools >= 43.0.0", "wheel"]
+
+[tool.isort]
+force_grid_wrap = 2
+include_trailing_comma = true
+multi_line_output = 3

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,5 +1,2 @@
 # requirements for a development environment
-nose
-coverage
-sphinx
-sphinx_rtd_theme
+-e .[devel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ devel =
     pytest
     pytest-cov
     coverage
+    sphinx
+    sphinx-rtd-theme
 
 [options.packages.find]
 # do not ship the build helpers

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ include_package_data = True
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
-    nose
+    pytest
+    pytest-cov
     coverage
 
 [options.packages.find]


### PR DESCRIPTION
Migration to pytest should be released to close `#1018335` in debian