### PR TITLE
Replace `simplejson` with `json`

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -2,13 +2,13 @@
 
 __docformat__ = 'restructuredtext'
 
-import re
+import json
 import logging
 import os
 import os.path as op
+import re
 import sys
 from shutil import copyfile
-from simplejson import loads
 
 from datalad.cmd import WitlessRunner
 from datalad.interface.base import Interface
@@ -48,7 +48,7 @@ def _resolve_img_url(url):
         req = requests.get(
             'https://www.singularity-hub.org/api/container/{}'.format(
                 url[7:]))
-        shub_info = loads(req.text)
+        shub_info = json.loads(req.text)
         url = shub_info['image']
     return url
 

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -100,10 +100,10 @@ class ContainersRun(Interface):
 
             # Temporary kludge to give a more helpful message
             if callspec.startswith("["):
-                import simplejson
+                import json
                 try:
-                    simplejson.loads(callspec)
-                except simplejson.errors.JSONDecodeError:
+                    json.loads(callspec)
+                except json.JSONDecodeError:
                     pass  # Never mind, false positive.
                 else:
                     raise ValueError(


### PR DESCRIPTION
Fixes issue #181 

This PR replaces `simplejson` with `json`. Merging this should stop the import error that will be introduced with the datalad PR #7014 (https://github.com/datalad/datalad/pull/7014) is released, because PR #7014 will remove `simplejson` from the requirements and `datalad-container` would stop working.

Merging this will also fix the datalad-container extension test error in PR #7014

