### PR TITLE
scriv.ini: Provide full relative path to the templates

### DIFF
--- a/changelog.d/pr-193.md
+++ b/changelog.d/pr-193.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- scriv.ini: Provide full relative path to the templates.  [PR #193](https://github.com/datalad/datalad-container/pull/193) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,6 +1,6 @@
 [scriv]
 fragment_directory = changelog.d
-entry_title_template = file: templates/entry_title.md.j2
-new_fragment_template = file: templates/new_fragment.md.j2
+entry_title_template = file: changelog.d/templates/entry_title.md.j2
+new_fragment_template = file: changelog.d/templates/new_fragment.md.j2
 format = md
 categories = 💥 Breaking Changes, 🚀 Enhancements and New Features, 🐛 Bug Fixes, 🔩 Dependencies, 📝 Documentation, 🏠 Internal, 🏎 Performance, 🧪 Tests


### PR DESCRIPTION
Release attempt failed due to scriv.exceptions.ScrivException: No such file: templates/entry_title.md.j2 .

I believe it is due to the change in scriv 1.1.0 — 2023-01-16.

    File names specified for file: settings will be interpreted relative
    to the current directory if they have path components. If the file name has no
    slashes or backslashes, then the old behavior remains: the file will be found
    in the fragment directory, or as a built-in template.

so let's release with this change