### PR TITLE
Capture stderr as well while trying for singularity or apptainer to avoid spurious stderr display

### DIFF
--- a/changelog.d/pr-208.md
+++ b/changelog.d/pr-208.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Capture stderr as well while trying for singularity or apptainer to avoid spurious stderr display.  [PR #208](https://github.com/datalad/datalad-container/pull/208) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad_container/extractors/_load_singularity_versions.py
+++ b/datalad_container/extractors/_load_singularity_versions.py
@@ -5,22 +5,21 @@ Adds:
     - external_versions["cmd:apptainer"]
     - external_versions["cmd:singularity"]
 """
-import subprocess
 
 from datalad.cmd import (
-    StdOutCapture,
+    StdOutErrCapture,
     WitlessRunner,
 )
 from datalad.support.external_versions import external_versions
 
 
 def __get_apptainer_version():
-    version = WitlessRunner().run("apptainer --version", protocol=StdOutCapture)['stdout'].strip()
+    version = WitlessRunner().run("apptainer --version", protocol=StdOutErrCapture)['stdout'].strip()
     return version.split("apptainer version ")[1]
 
 
 def __get_singularity_version():
-    return WitlessRunner().run("singularity version", protocol=StdOutCapture)['stdout'].strip()
+    return WitlessRunner().run("singularity version", protocol=StdOutErrCapture)['stdout'].strip()
 
 
 # Load external_versions and patch with "cmd:singularity" and "cmd:apptainer"


### PR DESCRIPTION
Otherwise user might see

    /bin/sh: 1: apptainer: not found

like I did while running the tests