### PR TITLE
BF: by default stop containers-run on error, to not proceed to save

### DIFF
--- a/changelog.d/pr-209.md
+++ b/changelog.d/pr-209.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: by default stop containers-run on error, to not proceed to save.  [PR #209](https://github.com/datalad/datalad-container/pull/209) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -66,6 +66,9 @@ class ContainersRun(Interface):
 
     _params_ = _run_params
 
+    # Analogous to 'run' command - stop on first error
+    on_failure = 'stop'
+
     @staticmethod
     @datasetmethod(name='containers_run')
     @eval_results


### PR DESCRIPTION
containers-run parallels run. run stops on error to not save the results. I was surprised to find that failed containers-run did fail BUT also saved the results.  IMHO such dichotomy in behavior makes little sense and hence here we make on_failure to be 'error' for the containers-run.

Note: interestingly it is only the  'run' command which has any non-default default on_failure:

	❯ git grep '^ *on_failure *=[^,)(]*$'
	datalad/core/local/run.py:    on_failure = 'stop'

so all commands by default 'continue' upon failure.