### PR TITLE
Add [extras] extras_require with datalad-metalad and add all those extras to [devel]

### DIFF
--- a/changelog.d/pr-215.md
+++ b/changelog.d/pr-215.md
@@ -1,0 +1,3 @@
+### 🏠 Internal
+
+- Add [extras] extras_require with datalad-metalad and add all those extras to [devel].  [PR #215](https://github.com/datalad/datalad-container/pull/215) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,3 +1,2 @@
 # requirements for a development environment
 -e .[devel]
-datalad-metalad

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,11 @@ packages = find:
 include_package_data = True
 
 [options.extras_require]
+extras =
+    datalad-metalad
 # this matches the name used by -core and what is expected by some CI setups
 devel =
+    %(extras)s
     pytest
     pytest-cov
     coverage


### PR DESCRIPTION
Development dependencies should be specified in setup.cfg as well, requirements*txt files should only reuse that setup.

Was missed during original PR code review I guess.