### PR TITLE
BF: make it [] in case of None being returned

### DIFF
--- a/changelog.d/pr-217.md
+++ b/changelog.d/pr-217.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- BF: make it [] in case of None being returned.  [PR #217](https://github.com/datalad/datalad-container/pull/217) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -95,7 +95,7 @@ def get_image(path, repo_tag=None, config=None):
     with open(manifest_path) as fp:
         manifest = json.load(fp)
     if repo_tag is not None:
-        manifest = [img for img in manifest if repo_tag in img.get("RepoTags", [])]
+        manifest = [img for img in manifest if repo_tag in (img.get("RepoTags") or [])]
     if config is not None:
         manifest = [img for img in manifest if img["Config"].startswith(config)]
     if len(manifest) == 0:


### PR DESCRIPTION
For some reason few days ago tests started to fail on github actions but not locally.  In the logs I see

	2023-08-09T02:10:57.8251783Z [ERROR] Failed to execute ['/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py', 'run', '--repo-tag', 'alpine:3.16', '/tmp/pytest-of-runner/pytest-0/test_load_multi_image0/alpine', 'ls']
	2023-08-09T02:10:57.8252806Z Traceback (most recent call last):
	2023-08-09T02:10:57.8254107Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 243, in <module>
	2023-08-09T02:10:57.8254681Z     main(sys.argv)
	2023-08-09T02:10:57.8255833Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 238, in main
	2023-08-09T02:10:57.8256433Z     namespace.func(namespace)
	2023-08-09T02:10:57.8257545Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 164, in cli_run
	2023-08-09T02:10:57.8258206Z     image_id = load(namespace.path, namespace.repo_tag, namespace.config)
	2023-08-09T02:10:57.8259431Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 135, in load
	2023-08-09T02:10:57.8260072Z     image_id = "sha256:" + get_image(path, repo_tag, config)
	2023-08-09T02:10:57.8261030Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 98, in get_image
	2023-08-09T02:10:57.8261689Z     manifest = [img for img in manifest if repo_tag in img.get("RepoTags", [])]
	2023-08-09T02:10:57.8262670Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 98, in <listcomp>
	2023-08-09T02:10:57.8263557Z     manifest = [img for img in manifest if repo_tag in img.get("RepoTags", [])]
	2023-08-09T02:10:57.8264146Z TypeError: argument of type 'NoneType' is not iterable
	2023-08-09T02:10:57.8265305Z Failed to execute ['/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py', 'run', '--repo-tag', 'alpine:3.16', '/tmp/pytest-of-runner/pytest-0/test_load_multi_image0/alpine', 'ls']
	2023-08-09T02:10:57.8266015Z Traceback (most recent call last):
	2023-08-09T02:10:57.8267005Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 243, in <module>
	2023-08-09T02:10:57.8267538Z     main(sys.argv)
	2023-08-09T02:10:57.8275594Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 238, in main
	2023-08-09T02:10:57.8276373Z     namespace.func(namespace)
	2023-08-09T02:10:57.8277519Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 164, in cli_run
	2023-08-09T02:10:57.8278199Z     image_id = load(namespace.path, namespace.repo_tag, namespace.config)
	2023-08-09T02:10:57.8279059Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 135, in load
	2023-08-09T02:10:57.8280204Z     image_id = "sha256:" + get_image(path, repo_tag, config)
	2023-08-09T02:10:57.8281300Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 98, in get_image
	2023-08-09T02:10:57.8281972Z     manifest = [img for img in manifest if repo_tag in img.get("RepoTags", [])]
	2023-08-09T02:10:57.8282831Z   File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/datalad_container/adapters/docker.py", line 98, in <listcomp>
	2023-08-09T02:10:57.8283464Z     manifest = [img for img in manifest if repo_tag in img.get("RepoTags", [])]
	2023-08-09T02:10:57.8284095Z TypeError: argument of type 'NoneType' is not iterable

which suggests that img.get("RepoTags", []) returns None, i.e. it is present but None, instead of just being absent and thus defaulting to [].  With this change we should "or" into [] then.

Closes (if succeeds testing) #216