### PR TITLE
Add readthedocs.yml config file from extension template

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+
+formats: all
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - path: .
+      method: pip
+    - requirements: requirements-devel.txt


### PR DESCRIPTION
The readthedocs build has been failing in recent builds, e.g. https://readthedocs.org/projects/datalad-container/builds/21818311/. This might be a reason behind #219. This PR adds the readthedocs.yml configuration from the datalad extension template, which is now required by readthedocs. 