### PR TITLE
Link essential user documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,9 @@ correct version prior execution.
 Documentation
 =============
 
+This is the technical documentation of the functionality and commands provided by this DataLad extension package.
+For an introduction to the general topic and a tutorial, please see the DataLad Handbook at https://handbook.datalad.org/r?containers.
+
 * :ref:`Documentation index <genindex>`
 * `API reference`_
 


### PR DESCRIPTION
This was previously needlessly too hard to find for people scanning the extension docs.