### PR TITLE
Add protection against invalid image path declarations for `add`

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -199,6 +199,16 @@ class ContainersAdd(Interface):
                              purpose='add container')
         runner = WitlessRunner()
 
+        if image is not None:
+            if op.isabs(image):
+                raise ValueError(
+                    f'image must be a relative path, got {image!r}')
+            if ds.pathobj.resolve() \
+                    not in (ds.pathobj / image).resolve().parents:
+                raise ValueError(
+                    'image must be a relative path pointing inside'
+                    f'the dataset, got {image!r}')
+
         # prevent madness in the config file
         if not re.match(r'^[0-9a-zA-Z-]+$', name):
             raise ValueError(

--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -206,7 +206,7 @@ class ContainersAdd(Interface):
             if ds.pathobj.resolve() \
                     not in (ds.pathobj / image).resolve().parents:
                 raise ValueError(
-                    'image must be a relative path pointing inside'
+                    'image must be a relative path pointing inside '
                     f'the dataset, got {image!r}')
 
         # prevent madness in the config file

--- a/datalad_container/tests/test_add.py
+++ b/datalad_container/tests/test_add.py
@@ -15,8 +15,27 @@ from datalad.utils import Path
 
 from datalad_container.containers_add import _ensure_datalad_remote
 
-# NOTE: At the moment, testing of the containers-add itself happens implicitly
-# via use in other tests.
+# NOTE: At the moment, most testing of the containers-add itself happens implicitly
+# this via use in other tests.
+
+common_kwargs = {'result_renderer': 'disabled'}
+
+
+def test_add_invalid_imgpath(tmp_path):
+    ds = Dataset(tmp_path).create(**common_kwargs)
+    # path spec must be relative
+    with pytest.raises(ValueError):
+        ds.containers_add(
+            'dummy',
+            image=tmp_path,
+            **common_kwargs
+        )
+    with pytest.raises(ValueError):
+        ds.containers_add(
+            'dummy',
+            image=Path('..', 'sneaky'),
+            **common_kwargs
+        )
 
 
 @with_tempfile


### PR DESCRIPTION
This is a bit painful, because datalad-next parameter validation is not available, but worth adding given the issue.

Closes #150