### PR TITLE
Move versioneer configuration from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 43.0.0", "wheel"]
+requires = ["setuptools >= 43.0.0", "tomli", "wheel"]
 
 [tool.isort]
 force_grid_wrap = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,14 @@ multi_line_output = 3
 skip = '.git,*.pdf,*.svg,venvs,versioneer.py,venvs'
 # DNE - do not exist
 ignore-words-list = 'dne'
+
+[tool.versioneer]
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+VCS = 'git'
+style = 'pep440'
+versionfile_source = 'datalad_container/_version.py'
+versionfile_build = 'datalad_container/_version.py'
+tag_prefix = ''
+parentdir_prefix = ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,17 +48,6 @@ datalad.extensions =
 datalad.metadata.extractors =
     container_inspect = datalad_container.extractors.metalad_container:MetaladContainerInspect
 
-[versioneer]
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-VCS = git
-style = pep440
-versionfile_source = datalad_container/_version.py
-versionfile_build = datalad_container/_version.py
-tag_prefix =
-parentdir_prefix =
-
 [coverage:report]
 show_missing = True
 omit =


### PR DESCRIPTION
versioneer became a bit too obnoxious in reporting its success and fail stories to the user in stdout which we rely on using as a result of an inquiry to setup.py:

	❯ python setup.py --name 2>/dev/null
	Failed to load config from /home/yoh/proj/datalad/datalad-container/pyproject.toml: 'versioneer'
	Try to load it from setup.cfg
	datalad_container
	❯ echo $?
	0

to workaround -- just moving its configuration to its preferred location - pyproject.toml and it starts to behave a bit better