### PR TITLE
BF: move check for metalad before import of meta_extract

### DIFF
--- a/datalad_container/extractors/tests/test_metalad_container.py
+++ b/datalad_container/extractors/tests/test_metalad_container.py
@@ -1,20 +1,24 @@
 import os.path as op
-import pytest
 import subprocess
 import sys
 from pathlib import Path
 from shutil import which
 from unittest.mock import patch
 
+import pytest
+from datalad.support.external_versions import (
+    UnknownVersion,
+    external_versions,
+)
 # Early detection before we try to import meta_extract
-from datalad.tests.utils_pytest import SkipTest  # noqa: E402, isort:skip
-from datalad.support.external_versions import external_versions, UnknownVersion  # noqa: E402, isort:skip
+from datalad.tests.utils_pytest import SkipTest
+
 if not external_versions["datalad_metalad"]:
     raise SkipTest("skipping metalad tests")
 
 from datalad.api import (
-    clone,
     Dataset,
+    clone,
     meta_extract,
 )
 from datalad.cmd import (
@@ -40,7 +44,9 @@ except RuntimeError:
     raise SkipTest("skipping singularity/apptainer tests")
 
 # Must come after skiptest or imports will not work
-from datalad_container.extractors.metalad_container import MetaladContainerInspect
+from datalad_container.extractors.metalad_container import (
+    MetaladContainerInspect,
+)
 
 
 @with_tempfile

--- a/datalad_container/extractors/tests/test_metalad_container.py
+++ b/datalad_container/extractors/tests/test_metalad_container.py
@@ -6,6 +6,12 @@ from pathlib import Path
 from shutil import which
 from unittest.mock import patch
 
+# Early detection before we try to import meta_extract
+from datalad.tests.utils_pytest import SkipTest  # noqa: E402, isort:skip
+from datalad.support.external_versions import external_versions, UnknownVersion  # noqa: E402, isort:skip
+if not external_versions["datalad_metalad"]:
+    raise SkipTest("skipping metalad tests")
+
 from datalad.api import (
     clone,
     Dataset,
@@ -16,7 +22,6 @@ from datalad.cmd import (
     WitlessRunner,
 )
 from datalad.support.exceptions import CommandError
-from datalad.support.external_versions import external_versions, UnknownVersion
 from datalad.tests.utils_pytest import (
     SkipTest,
     assert_in,
@@ -26,9 +31,6 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
     with_tree,
 )
-
-if not external_versions["datalad_metalad"]:
-    raise SkipTest("skipping metalad tests")
 
 from datalad_container.utils import get_container_command
 


### PR DESCRIPTION
Otherwise we try to import meta_extract and it fails.  Failed the build of datalad-container for debian

I will shortly bundle also run of isort on that file to ensure that pragmas are effective