### PR TITLE
Run isort across entire codebase

### DIFF
--- a/_datalad_buildsupport/setup.py
+++ b/_datalad_buildsupport/setup.py
@@ -8,12 +8,15 @@
 
 import datetime
 import os
-
 from os.path import (
     dirname,
     join as opj,
 )
-from setuptools import Command, DistutilsOptionError
+
+from setuptools import (
+    Command,
+    DistutilsOptionError,
+)
 from setuptools.config import read_configuration
 
 import versioneer
@@ -210,8 +213,8 @@ class BuildConfigInfo(Command):
         if not os.path.exists(opath):
             os.makedirs(opath)
 
-        from datalad.interface.common_cfg import definitions as cfgdefs
         from datalad.dochelpers import _indent
+        from datalad.interface.common_cfg import definitions as cfgdefs
 
         categories = {
             'global': {},

--- a/datalad_container/__init__.py
+++ b/datalad_container/__init__.py
@@ -3,7 +3,7 @@
 __docformat__ = 'restructuredtext'
 
 # Imported to set singularity/apptainer version commands at init
-import datalad_container.extractors._load_singularity_versions # noqa
+import datalad_container.extractors._load_singularity_versions  # noqa
 
 # defines a datalad command suite
 # this symbold must be identified as a setuptools entrypoint
@@ -47,9 +47,10 @@ command_suite = (
     ]
 )
 
-from datalad.support.extensions import register_config
 from os.path import join as opj
+
 from datalad.support.constraints import EnsureStr
+from datalad.support.extensions import register_config
 
 register_config(
     'datalad.containers.location',
@@ -62,4 +63,5 @@ register_config(
 )
 
 from . import _version
+
 __version__ = _version.get_versions()['version']

--- a/datalad_container/_version.py
+++ b/datalad_container/_version.py
@@ -12,12 +12,19 @@
 """Git implementation of _version.py."""
 
 import errno
+import functools
 import os
 import re
 import subprocess
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple
-import functools
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
 
 
 def get_keywords() -> Dict[str, str]:

--- a/datalad_container/adapters/docker.py
+++ b/datalad_container/adapters/docker.py
@@ -11,6 +11,7 @@ command-line interface.
 
 import hashlib
 import json
+import logging
 import os
 import os.path as op
 import subprocess as sp
@@ -18,11 +19,7 @@ import sys
 import tarfile
 import tempfile
 
-import logging
-
-from datalad.utils import (
-    on_windows,
-)
+from datalad.utils import on_windows
 
 lgr = logging.getLogger("datalad.containers.adapters.docker")
 

--- a/datalad_container/adapters/tests/test_docker.py
+++ b/datalad_container/adapters/tests/test_docker.py
@@ -1,7 +1,10 @@
 import json
 import os.path as op
-from shutil import unpack_archive, which
 import sys
+from shutil import (
+    unpack_archive,
+    which,
+)
 
 import pytest
 from datalad.cmd import (

--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -6,24 +6,31 @@ import json
 import logging
 import os
 import os.path as op
+import re
 from pathlib import (
     Path,
     PurePosixPath,
 )
-import re
 from shutil import copyfile
 
 from datalad.cmd import WitlessRunner
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.support.param import Parameter
-from datalad.distribution.dataset import datasetmethod, EnsureDataset
-from datalad.distribution.dataset import require_dataset
-from datalad.interface.base import eval_results
-from datalad.support.constraints import EnsureStr
-from datalad.support.constraints import EnsureNone
-from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
 from datalad.interface.results import get_status_dict
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.param import Parameter
 
 from .utils import get_container_configuration
 

--- a/datalad_container/containers_list.py
+++ b/datalad_container/containers_list.py
@@ -5,18 +5,24 @@ __docformat__ = 'restructuredtext'
 import logging
 import os.path as op
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.interface.common_opts import recursion_flag
-from datalad.support.param import Parameter
-from datalad.distribution.dataset import datasetmethod, EnsureDataset, Dataset
-from datalad.distribution.dataset import require_dataset
-from datalad.interface.utils import default_result_renderer
-from datalad.interface.base import eval_results
-from datalad.support.constraints import EnsureNone
 import datalad.support.ansi_colors as ac
-from datalad.interface.results import get_status_dict
 from datalad.coreapi import subdatasets
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
+from datalad.interface.common_opts import recursion_flag
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import default_result_renderer
+from datalad.support.constraints import EnsureNone
+from datalad.support.param import Parameter
 from datalad.ui import ui
 
 from datalad_container.utils import get_container_configuration

--- a/datalad_container/containers_remove.py
+++ b/datalad_container/containers_remove.py
@@ -5,15 +5,22 @@ __docformat__ = 'restructuredtext'
 import logging
 import os.path as op
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.support.param import Parameter
-from datalad.distribution.dataset import datasetmethod, EnsureDataset
-from datalad.distribution.dataset import require_dataset
-from datalad.interface.base import eval_results
-from datalad.support.constraints import EnsureNone
-from datalad.support.constraints import EnsureStr
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
 from datalad.interface.results import get_status_dict
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.param import Parameter
 from datalad.utils import rmtree
 
 from datalad_container.utils import get_container_configuration

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -6,21 +6,25 @@ import logging
 import os.path as op
 import sys
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.support.param import Parameter
-from datalad.distribution.dataset import datasetmethod
-from datalad.distribution.dataset import require_dataset
-from datalad.interface.base import eval_results
-from datalad.utils import ensure_iter
-
-from datalad.interface.results import get_status_dict
 from datalad.core.local.run import (
     Run,
     get_command_pwds,
     normalize_command,
     run_command,
 )
+from datalad.distribution.dataset import (
+    datasetmethod,
+    require_dataset,
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
+from datalad.interface.results import get_status_dict
+from datalad.support.param import Parameter
+from datalad.utils import ensure_iter
+
 from datalad_container.find_container import find_container_
 
 lgr = logging.getLogger("datalad.containers.containers_run")
@@ -76,7 +80,8 @@ class ContainersRun(Interface):
     def __call__(cmd, container_name=None, dataset=None,
                  inputs=None, outputs=None, message=None, expand=None,
                  explicit=False, sidecar=None):
-        from unittest.mock import patch  # delayed, since takes long (~600ms for yoh)
+        from unittest.mock import \
+            patch  # delayed, since takes long (~600ms for yoh)
         pwd, _ = get_command_pwds(dataset)
         ds = require_dataset(dataset, check_installed=True,
                              purpose='run a containerized command execution')

--- a/datalad_container/extractors/metalad_container.py
+++ b/datalad_container/extractors/metalad_container.py
@@ -13,12 +13,18 @@ import subprocess
 import time
 from uuid import UUID
 
-from datalad.support.external_versions import external_versions, UnknownVersion
-from datalad_metalad.extractors.base import DataOutputCategory, ExtractorResult, FileMetadataExtractor
+from datalad.support.external_versions import (
+    UnknownVersion,
+    external_versions,
+)
 from datalad_metalad import get_file_id
+from datalad_metalad.extractors.base import (
+    DataOutputCategory,
+    ExtractorResult,
+    FileMetadataExtractor,
+)
 
 from datalad_container.utils import get_container_command
-
 
 CURRENT_VERSION = "0.0.1"
 

--- a/datalad_container/find_container.py
+++ b/datalad_container/find_container.py
@@ -97,6 +97,7 @@ def _get_container_by_name(_, name, containers):
 
 def _get_container_by_path(ds, name, containers):
     from datalad.distribution.dataset import resolve_path
+
     # Note: since datalad0.12.0rc6 resolve_path returns a Path object here,
     #       which then fails to equal c['path'] below as this is taken from
     #       config as a string

--- a/datalad_container/tests/fixtures/singularity_image.py
+++ b/datalad_container/tests/fixtures/singularity_image.py
@@ -1,11 +1,11 @@
-import pytest
 from pathlib import Path
 
+import pytest
 from datalad.api import Dataset
 from datalad.tests.utils_pytest import with_tempfile
 
-from datalad_container.utils import get_container_command
 from datalad_container.tests.utils import add_pyscript_image
+from datalad_container.utils import get_container_command
 
 TEST_IMG_URL = 'shub://datalad/datalad-container:testhelper'
 

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -1,6 +1,7 @@
 import os
 import os.path as op
 
+import pytest
 from datalad.api import (
     Dataset,
     clone,
@@ -9,11 +10,11 @@ from datalad.api import (
     containers_run,
     create,
 )
-from datalad.local.rerun import get_run_info
 from datalad.cmd import (
     StdOutCapture,
     WitlessRunner,
 )
+from datalad.local.rerun import get_run_info
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.network import get_local_file_url
 from datalad.tests.utils_pytest import (
@@ -36,7 +37,6 @@ from datalad.utils import (
     on_windows,
 )
 
-import pytest
 from datalad_container.tests.utils import add_pyscript_image
 
 testimg_url = 'shub://datalad/datalad-container:testhelper'

--- a/datalad_container/tests/utils.py
+++ b/datalad_container/tests/utils.py
@@ -3,9 +3,9 @@ import os.path as op
 import sys
 
 from datalad.api import containers_add
-from datalad.utils import chpwd
-from datalad.tests.utils_pytest import SkipTest
 from datalad.interface.common_cfg import dirs as appdirs
+from datalad.tests.utils_pytest import SkipTest
+from datalad.utils import chpwd
 
 
 def add_pyscript_image(ds, container_name, file_name):

--- a/datalad_container/utils.py
+++ b/datalad_container/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 # the pathlib equivalent is only available in PY3.12
 from os.path import lexists
-
 from pathlib import (
     PurePath,
     PurePosixPath,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,17 +12,16 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-
 import datetime
+import os
+import sys
+from os import pardir
 from os.path import (
     abspath,
     dirname,
     exists,
     join as opj,
 )
-from os import pardir
 
 import datalad_container
 

--- a/docs/utils/pygments_ansi_color.py
+++ b/docs/utils/pygments_ansi_color.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 """Pygments lexer for text containing ANSI color codes."""
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import itertools
 import re
 
 import pygments.lexer
 import pygments.token
-
 
 Color = pygments.token.Token.Color
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = ["setuptools >= 43.0.0", "tomli", "wheel"]
 force_grid_wrap = 2
 include_trailing_comma = true
 multi_line_output = 3
+combine_as_imports = true
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,venvs,versioneer.py,venvs'

--- a/tools/containers_add_dhub_tags.py
+++ b/tools/containers_add_dhub_tags.py
@@ -16,11 +16,11 @@ The step of adding the image is skipped if the path is already present locally.
 import fileinput
 import json
 import logging
+import re
 from pathlib import Path
 from pprint import pprint
-import re
-import requests
 
+import requests
 from datalad.api import (
     containers_add,
     save,


### PR DESCRIPTION
- for consistency since we already have `isort` configuration
- to trigger a release ;)

I hope there would be no side-effects on the order of imports -- all trust goes into tests!