### PR TITLE
Improving documentation for --url parameter

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -138,7 +138,8 @@ class ContainersAdd(Interface):
             the rest of the URL will be interpreted as the argument to
             'docker pull', the image will be saved to a location
             specified by `name`, and the call format will be auto-configured
-            to run docker, unless overwritten.""",
+            to run docker, unless overwritten. The auto-configured call to docker 
+            run mounts the cwd to '/tmp' and sets the working directory to '/tmp'.""",
             metavar="URL",
             constraints=EnsureStr() | EnsureNone(),
         ),

--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -139,7 +139,7 @@ class ContainersAdd(Interface):
             'docker pull', the image will be saved to a location
             specified by `name`, and the call format will be auto-configured
             to run docker, unless overwritten. The auto-configured call to docker 
-            run mounts the cwd to '/tmp' and sets the working directory to '/tmp'.""",
+            run mounts the CWD to '/tmp' and sets the working directory to '/tmp'.""",
             metavar="URL",
             constraints=EnsureStr() | EnsureNone(),
         ),


### PR DESCRIPTION
Adding documentation regarding the default behaviour of "cli_run" in adapter "docker.py", which is called when --url should fetch from docker-hub.

Maybe it is also helpful for the user to mention the use of the "docker adapter" in the docs.