### PR TITLE
MNT: Account for a number of deprecations in core

### DIFF
--- a/changelog.d/pr-268.md
+++ b/changelog.d/pr-268.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- MNT: Account for a number of deprecations in core.  [PR #268](https://github.com/datalad/datalad-container/pull/268) (by [@adswa](https://github.com/adswa))

--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -275,7 +275,7 @@ class ContainersAdd(Interface):
                 # XXX: check=False is used to avoid dropping the image. It
                 # should use drop=False if remove() gets such an option (see
                 # DataLad's gh-2673).
-                for r in ds.remove(image, save=False, check=False,
+                for r in ds.remove(image, reckless='availability',
                                    return_type="generator"):
                     yield r
 

--- a/datalad_container/tests/test_containers.py
+++ b/datalad_container/tests/test_containers.py
@@ -107,7 +107,7 @@ def test_container_files(ds_path=None, local_file=None, url=None):
     # non-default location:
     ds.config.add("datalad.containers.location",
                   value=op.join(".datalad", "test-environments"),
-                  where='dataset')
+                  scope='branch')
     ds.save(message="Configure container mountpoint", **common_kwargs)
 
     # no containers yet:
@@ -278,7 +278,7 @@ def test_container_from_subdataset(ds_path=None, src_subds_path=None, local_file
     # not installed subdataset doesn't pose an issue:
     sub2 = ds.create("sub2", **common_kwargs)
     assert_result_count(ds.subdatasets(**common_kwargs), 2, type="dataset")
-    ds.uninstall("sub2", check=False, **common_kwargs)
+    ds.drop("sub2", reckless='availability', what='datasets', **common_kwargs)
     from datalad.tests.utils_pytest import assert_false
     assert_false(sub2.is_installed())
 


### PR DESCRIPTION
this reduces the number of deprecation warnings when running the test suite