### PR TITLE
BF: use setuptools.errors.OptionError instead of now removed import of distutils.DistutilsOptionError

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,13 +13,13 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install -r requirements-devel.txt
         pip install .
     - name: Build docs

--- a/_datalad_buildsupport/setup.py
+++ b/_datalad_buildsupport/setup.py
@@ -12,12 +12,9 @@ from os.path import (
     dirname,
     join as opj,
 )
-
-from setuptools import (
-    Command,
-    DistutilsOptionError,
-)
+from setuptools import Command
 from setuptools.config import read_configuration
+from setuptools.errors import OptionError
 
 import versioneer
 
@@ -54,11 +51,11 @@ class BuildManPage(Command):
 
     def finalize_options(self):
         if self.manpath is None:
-            raise DistutilsOptionError('\'manpath\' option is required')
+            raise OptionError('\'manpath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         if self.parser is None:
-            raise DistutilsOptionError('\'parser\' option is required')
+            raise OptionError('\'parser\' option is required')
         mod_name, func_name = self.parser.split(':')
         fromlist = mod_name.split('.')
         try:
@@ -173,9 +170,9 @@ class BuildRSTExamplesFromScripts(Command):
 
     def finalize_options(self):
         if self.expath is None:
-            raise DistutilsOptionError('\'expath\' option is required')
+            raise OptionError('\'expath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.announce('Converting example scripts')
 
     def run(self):
@@ -205,7 +202,7 @@ class BuildConfigInfo(Command):
 
     def finalize_options(self):
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.announce('Generating configuration documentation')
 
     def run(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 43.0.0", "tomli", "wheel"]
+requires = ["setuptools >= 59.0.0", "tomli", "wheel"]
 
 [tool.isort]
 force_grid_wrap = 2


### PR DESCRIPTION
setuptools.errors were introduced in 59.0.0 release.

See https://github.com/pypa/setuptools/issues/5000 for more rationale
etc.