### PR TITLE
Upgrade appveyor to freshier base Ubuntu 22.04 to pass testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,7 +60,7 @@ environment:
   # All of these are common to all matrix runs ATM, so pre-defined here and to be overloaded if needed
   DTS: datalad_container
   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
-  INSTALL_SYSPKGS: python3-venv xz-utils jq
+  INSTALL_SYSPKGS: python3-venv xz-utils jq libffi7
   # system git-annex is way too old, use better one
   INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
   CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,7 +59,7 @@ environment:
 
   # All of these are common to all matrix runs ATM, so pre-defined here and to be overloaded if needed
   DTS: datalad_container
-  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
   INSTALL_SYSPKGS: python3-venv xz-utils jq
   # system git-annex is way too old, use better one
   INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb

--- a/changelog.d/pr-278.md
+++ b/changelog.d/pr-278.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- Upgrade appveyor to freshier base Ubuntu 22.04 to pass testing.  [PR #278](https://github.com/datalad/datalad-container/pull/278) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
CPed from
- #277 