### PR TITLE
Add testing under a crippled FS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ environment:
   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
   INSTALL_SYSPKGS: python3-venv xz-utils jq libffi7
   # system git-annex is way too old, use better one
-  INSTALL_GITANNEX: git-annex -m datalad/packages
+  INSTALL_GITANNEX: git-annex -m deb-url --url https://datasets.datalad.org/datalad/packages/neurodebian/git-annex-standalone_10.20230126-1~ndall+1_amd64.deb
   CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
 
   matrix:

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         pip install -r requirements-devel.txt
         python -m pip install --upgrade pip
+        tools/ci/install-singularity.sh
     - name: Installation
       run: |
         # package install

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -1,0 +1,55 @@
+name: crippled-filesystems
+
+on: [pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up system
+      shell: bash
+      run: |
+        bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+        # enable repo for devel git-annex, if needed
+        #sudo sed -e 's|\(deb.*data\)|#\1|' -e 's|/debian |/debian-devel |' /etc/apt/sources.list.d/neurodebian.sources.list | sudo tee /etc/apt/sources.list.d/neurodebian-devel.sources.list
+        sudo apt-get update -qq
+        sudo apt-get install eatmydata
+        sudo eatmydata apt-get install git-annex-standalone dosfstools
+        # 500 MB VFAT FS in a box
+        sudo dd if=/dev/zero of=/crippledfs.img count=500 bs=1M
+        sudo mkfs.vfat /crippledfs.img
+        # mount
+        sudo mkdir /crippledfs
+        sudo mount -o "uid=$(id -u),gid=$(id -g)" /crippledfs.img /crippledfs
+    - name: Set up environment
+      run: |
+        git config --global user.email "test@github.land"
+        git config --global user.name "GitHub Almighty"
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        pip install -r requirements-devel.txt
+        python -m pip install --upgrade pip
+    - name: Installation
+      run: |
+        # package install
+        python -m pip install .
+    - name: Run tests
+      env:
+        # forces all test repos/paths into the VFAT FS
+        TMPDIR: /crippledfs
+      run: |
+        mkdir -p __testhome__
+        cd __testhome__
+        # give detailed info on actual test setup
+        datalad wtf
+        echo "== mount >>"
+        mount
+        echo "<< mount =="
+        python -m pytest -s -v --doctest-modules --cov=datalad_container --pyargs datalad_container


### PR DESCRIPTION
sits on top of
- #278 
to avoid complaints from appveyor

TODOs
- [ ] address 3 failing tests
```
FAILED ../tests/test_containers.py::test_container_update - AssertionError
FAILED ../tests/test_run.py::test_extra_inputs - AttributeError: 'NoneType' object has no attribute 'get'
FAILED ../tests/test_schemes.py::test_docker - datalad.runner.exception.CommandError: CommandError: 'singularity build image docker://busybox@sha256:7964ad52e396a6e045c39b5a44438424ac52e12e4d5a25d94895f2058cb863a0' failed with exitcode 255 under /crippledfs/datalad_temp_test_docker2kzv5u76/.datalad/environments/bb
```

edit: might not show that CI run below but it is available under https://github.com/datalad/datalad-container/actions/workflows/test_crippledfs.yml 