### PR TITLE
add missing run params

### DIFF
--- a/changelog.d/pr-286.md
+++ b/changelog.d/pr-286.md
@@ -1,3 +1,3 @@
 ### 🐛 Bug Fixes
 
-- add missing run params.  [PR #286](https://github.com/datalad/datalad-container/pull/286) (by [@bpinsard](https://github.com/bpinsard))
+- add missing run params `assume_ready`, `dry_run` and `jobs`.  [PR #286](https://github.com/datalad/datalad-container/pull/286) (by [@bpinsard](https://github.com/bpinsard))

--- a/changelog.d/pr-286.md
+++ b/changelog.d/pr-286.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- add missing run params.  [PR #286](https://github.com/datalad/datalad-container/pull/286) (by [@bpinsard](https://github.com/bpinsard))

--- a/datalad_container/containers_run.py
+++ b/datalad_container/containers_run.py
@@ -77,9 +77,10 @@ class ContainersRun(Interface):
     @staticmethod
     @datasetmethod(name='containers_run')
     @eval_results
-    def __call__(cmd, container_name=None, dataset=None,
-                 inputs=None, outputs=None, message=None, expand=None,
-                 explicit=False, sidecar=None):
+    def __call__(cmd, container_name=None, dataset=None, message=None,
+                 inputs=None, outputs=None, assume_ready=None, expand=None,
+                 explicit=False, sidecar=None,
+                 dry_run=None, jobs=None):
         from unittest.mock import \
             patch  # delayed, since takes long (~600ms for yoh)
         pwd, _ = get_command_pwds(dataset)
@@ -185,8 +186,11 @@ class ContainersRun(Interface):
                     inputs=inputs,
                     extra_inputs=[image_path] + extra_inputs,
                     outputs=outputs,
+                    assume_ready=assume_ready,
                     message=message,
                     expand=expand,
                     explicit=explicit,
-                    sidecar=sidecar):
+                    sidecar=sidecar,
+                    dry_run=dry_run,
+                    jobs=jobs):
                 yield r

--- a/datalad_container/tests/test_run.py
+++ b/datalad_container/tests/test_run.py
@@ -276,6 +276,44 @@ def test_extra_inputs(path=None):
     ) == set(runinfo.get("extra_inputs", set()))
 
 
+@pytest.mark.ai_generated
+@with_tree(tree={"i.img": "doesn't matter"})
+def test_run_new_params(path=None):
+    """Test that dry_run, assume_ready, and jobs parameters are passed through."""
+    ds = Dataset(path).create(force=True, **common_kwargs)
+    ds.containers_add(
+        "i",
+        image="i.img",
+        call_fmt="sh -c '{cmd}'",
+        **common_kwargs
+    )
+    ds.save(**common_kwargs)
+    ok_clean_git(path)
+
+    # Test dry_run='basic': no command should be executed
+    output_file = op.join(path, "output.txt")
+    ds.containers_run(
+        ["touch output.txt"],
+        dry_run="basic",
+        **common_kwargs
+    )
+    # The output file should NOT exist because dry_run prevents execution
+    assert_false(op.exists(output_file))
+    # Repository should still be clean (no changes made)
+    ok_clean_git(path)
+
+    # Test assume_ready and jobs together with actual execution
+    # assume_ready='inputs' skips input availability check
+    # jobs=2 sets parallelization level
+    ds.containers_run(
+        ["touch output.txt"],
+        assume_ready="inputs",
+        jobs=2,
+        **common_kwargs
+    )
+    ok_(op.exists(output_file))
+
+
 @skip_if_no_network
 @with_tree(tree={"subdir": {"in": "innards"}})
 def test_run_no_explicit_dataset(path=None):


### PR DESCRIPTION
`--dry-run` `--assume-ready` and `--jobs`  params were not used even if imported from the `Run` command.